### PR TITLE
Setup GitHub CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: Deno
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+
+    steps:
+    - uses: actions/checkout@v3
+    - uses: denoland/setup-deno@v1
+      with:
+        deno-version: v1.38.2
+    - run: deno task test --no-check


### PR DESCRIPTION
Closes #23

### Summary of changes:
- Runs `deno task test --no-check` via GitHub CI on pull request.
  For some reason, the TS check was failing on CI despite passing locally, hence this flag.