### PR TITLE
replace npx with deno

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "tasks": {
     "chel": "deno task lint && deno task build && deno run --allow-net --allow-read=. --allow-write=. build/main.js",
-    "lint": "npx eslint ./src ./scripts",
+    "lint": "deno run --allow-env --allow-read --allow-sys --deny-sys=\"networkInterfaces\" npm:eslint@9.31.0 ./src ./scripts",
     "compile": "deno run --allow-run --allow-read=. --allow-write=./dist scripts/compile.ts",
     "build": "deno run --node-modules-dir --allow-run --allow-read --allow-env --allow-write=./build --allow-net scripts/build.ts",
     "dist": "deno lint . && deno task lint && deno task build && deno task compile",

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "tasks": {
     "chel": "deno task lint && deno task build && deno run --allow-net --allow-read=. --allow-write=. build/main.js",
-    "lint": "deno run --allow-env --allow-read --allow-sys --deny-sys=\"networkInterfaces\" npm:eslint@9.31.0 ./src ./scripts",
+    "lint": "deno run --allow-env --allow-read=. --allow-sys --deny-sys=\"networkInterfaces\" npm:eslint@9.31.0 ./src ./scripts",
     "compile": "deno run --allow-run --allow-read=. --allow-write=./dist scripts/compile.ts",
     "build": "deno run --node-modules-dir --allow-run --allow-read --allow-env --allow-write=./build --allow-net scripts/build.ts",
     "dist": "deno lint . && deno task lint && deno task build && deno task compile",

--- a/deno.json
+++ b/deno.json
@@ -5,7 +5,7 @@
     "compile": "deno run --allow-run --allow-read=. --allow-write=./dist scripts/compile.ts",
     "build": "deno run --node-modules-dir --allow-run --allow-read=. --allow-env --allow-write=./build --allow-net scripts/build.ts",
     "dist": "deno lint . && deno task lint && deno task build && deno task compile",
-    "test": "deno task lint && deno test --allow-read=.,~/.cache --allow-write=. --allow-env --allow-ffi --allow-net"
+    "test": "deno task lint && deno test --allow-read=.,$HOME/.cache --allow-write=. --allow-env --allow-ffi --allow-net"
   },
   "imports": {
     "~/": "./src/",

--- a/deno.json
+++ b/deno.json
@@ -5,7 +5,7 @@
     "compile": "deno run --allow-run --allow-read=. --allow-write=./dist scripts/compile.ts",
     "build": "deno run --node-modules-dir --allow-run --allow-read=. --allow-env --allow-write=./build --allow-net scripts/build.ts",
     "dist": "deno lint . && deno task lint && deno task build && deno task compile",
-    "test": "deno task lint && deno test --allow-read=. --allow-write=. --allow-env --allow-ffi --allow-net"
+    "test": "deno task lint && deno test --allow-read=.,~/.cache --allow-write=. --allow-env --allow-ffi --allow-net"
   },
   "imports": {
     "~/": "./src/",

--- a/deno.json
+++ b/deno.json
@@ -3,9 +3,9 @@
     "chel": "deno task lint && deno task build && deno run --allow-net --allow-read=. --allow-write=. build/main.js",
     "lint": "deno run --allow-env --allow-read=. --allow-sys --deny-sys=\"networkInterfaces\" npm:eslint@9.31.0 ./src ./scripts",
     "compile": "deno run --allow-run --allow-read=. --allow-write=./dist scripts/compile.ts",
-    "build": "deno run --node-modules-dir --allow-run --allow-read --allow-env --allow-write=./build --allow-net scripts/build.ts",
+    "build": "deno run --node-modules-dir --allow-run --allow-read=. --allow-env --allow-write=./build --allow-net scripts/build.ts",
     "dist": "deno lint . && deno task lint && deno task build && deno task compile",
-    "test": "deno task lint && deno test --allow-read --allow-write --allow-env --allow-ffi --allow-net"
+    "test": "deno task lint && deno test --allow-read=. --allow-write --allow-env --allow-ffi --allow-net"
   },
   "imports": {
     "~/": "./src/",

--- a/deno.json
+++ b/deno.json
@@ -1,11 +1,11 @@
 {
   "tasks": {
     "chel": "deno task lint && deno task build && deno run --allow-net --allow-read=. --allow-write=. build/main.js",
-    "lint": "deno run --allow-env --allow-read=. --allow-sys --deny-sys=\"networkInterfaces\" npm:eslint@9.31.0 ./src ./scripts",
+    "lint": "deno run --allow-env --allow-read --allow-sys --deny-sys=\"networkInterfaces\" npm:eslint@9.31.0 ./src ./scripts",
     "compile": "deno run --allow-run --allow-read=. --allow-write=./dist scripts/compile.ts",
     "build": "deno run --node-modules-dir --allow-run --allow-read=. --allow-env --allow-write=./build --allow-net scripts/build.ts",
     "dist": "deno lint . && deno task lint && deno task build && deno task compile",
-    "test": "deno task lint && deno test --allow-read=.,$HOME/.cache --allow-write=.,$HOME/.cache --allow-env --allow-ffi --allow-net"
+    "test": "deno task lint && deno test --allow-read=.,$HOME/.cache,$HOME/Library/Caches/deno --allow-write=.,$HOME/.cache,$HOME/Library/Caches/deno --allow-env --allow-ffi --allow-net"
   },
   "imports": {
     "~/": "./src/",

--- a/deno.json
+++ b/deno.json
@@ -5,7 +5,7 @@
     "compile": "deno run --allow-run --allow-read=. --allow-write=./dist scripts/compile.ts",
     "build": "deno run --node-modules-dir --allow-run --allow-read=. --allow-env --allow-write=./build --allow-net scripts/build.ts",
     "dist": "deno lint . && deno task lint && deno task build && deno task compile",
-    "test": "deno task lint && deno test --allow-read=.,$HOME/.cache --allow-write=. --allow-env --allow-ffi --allow-net"
+    "test": "deno task lint && deno test --allow-read=.,$HOME/.cache --allow-write=.,$HOME/.cache --allow-env --allow-ffi --allow-net"
   },
   "imports": {
     "~/": "./src/",

--- a/deno.json
+++ b/deno.json
@@ -5,7 +5,7 @@
     "compile": "deno run --allow-run --allow-read=. --allow-write=./dist scripts/compile.ts",
     "build": "deno run --node-modules-dir --allow-run --allow-read=. --allow-env --allow-write=./build --allow-net scripts/build.ts",
     "dist": "deno lint . && deno task lint && deno task build && deno task compile",
-    "test": "deno task lint && deno test --allow-read=. --allow-write --allow-env --allow-ffi --allow-net"
+    "test": "deno task lint && deno test --allow-read=. --allow-write=. --allow-env --allow-ffi --allow-net"
   },
   "imports": {
     "~/": "./src/",

--- a/deno.lock
+++ b/deno.lock
@@ -29,6 +29,8 @@
     "npm:@types/node@24.0.13": "24.0.13",
     "npm:axios@0.27.2": "0.27.2",
     "npm:esbuild@0.25.6": "0.25.6",
+    "npm:eslint@*": "9.31.0",
+    "npm:eslint@9.31.0": "9.31.0",
     "npm:multiformats@11.0.2": "11.0.2",
     "npm:rimraf@3.0.2": "3.0.2",
     "npm:tar@6.1.11": "6.1.11",


### PR DESCRIPTION
Do not use `npx` — ever.

This helps protect against supply-chain attacks.

![Screenshot 2025-07-23 at 10 42 45 AM](https://github.com/user-attachments/assets/975e7d24-d6ce-4373-8782-f3021a97c7b5)
