### PR TITLE
Fix manifest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ chel version
 chel pin [--dir <output-directory>] [--overwrite] <manifest-file-path> <version>
 chel test
 chel keygen [--out=<key.json>]
-chel manifest [-k|--key <pubkey1> [-k|--key <pubkey2> ...]] [--out=<manifest.json>] [-s|--slim <contract-slim.js>] [-v|--version <version>] <key.json> <contract-bundle.js>
+chel manifest [-k|--key <pubkey1> [-k|--key <pubkey2> ...]] [--out=<manifest.json>] [-s|--slim <contract-slim.js>] [-V|--contract-version <version>] <key.json> <contract-bundle.js>
 chel deploy <url-or-dir-or-sqlitedb> <contract-manifest.json> [<manifest2.json> [<manifest3.json> ...]]
 chel upload <url-or-dir-or-sqlitedb> <file1> [<file2> [<file3> ...]]
 chel serve [options] <directory>

--- a/build/main.js
+++ b/build/main.js
@@ -110353,7 +110353,7 @@ async function manifest(args) {
   const parsedFilepath = parse7(contractFile);
   const { name: contractFileName, base: contractBasename, dir: contractDir } = parsedFilepath;
   const name = args.name || contractFileName;
-  const version3 = args.version || "x";
+  const version3 = args.contractVersion || "x";
   const slim = args.slim;
   const outFile = args.out || join8(contractDir, `${contractFileName}.${version3}.manifest.json`);
   if (!keyFile) exit("Missing signing key file");
@@ -110430,11 +110430,11 @@ var module8 = {
       describe: "Slim contract bundle",
       requiresArg: true,
       string: true
-    }).alias("s", "slim").option("version", {
+    }).alias("s", "slim").option("contract-version", {
       describe: "Contract version",
       requiresArg: true,
       string: true
-    }).alias("v", "version").positional("signingKey", {
+    }).alias("V", "contract-version").positional("signingKey", {
       describe: "Signing key file",
       demandOption: true,
       type: "string"
@@ -110444,7 +110444,7 @@ var module8 = {
       type: "string"
     });
   },
-  command: "manifest [-k|--key <pubkey1>] [-k|--key <pubkey2> ...] [--out <manifest.json>] [-s|--slim <contract-slim.js>] [-v|--version <version>] <signingKey> <contractBundle>",
+  command: "manifest [-k|--key <pubkey1>] [-k|--key <pubkey2> ...] [--out <manifest.json>] [-s|--slim <contract-slim.js>] [-V|--contract-version <version>] <signingKey> <contractBundle>",
   describe: "Produce a signed manifest from a contract.\nIf unspecified, <version> is set to 'x'.",
   postHandler: (argv) => {
     return manifest(argv);
@@ -111012,7 +111012,7 @@ var module12 = {
   }
 };
 function version2() {
-  console.log("3.2.0");
+  console.log("3.2.1");
 }
 var module13 = {
   command: "version",
@@ -115156,7 +115156,7 @@ var parseArgs = () => {
   const commandModules = Object.values(commands_exports).map(
     (c) => handlerWrapper(c)
   );
-  return yargs_default(hideBin(process13.argv)).version("3.2.0").strict().command(commandModules).demandCommand().help();
+  return yargs_default(hideBin(process13.argv)).version("3.2.1").strict().command(commandModules).demandCommand();
 };
 var parseArgs_default = parseArgs;
 var parseConfig = () => {

--- a/build/main.js
+++ b/build/main.js
@@ -115156,7 +115156,7 @@ var parseArgs = () => {
   const commandModules = Object.values(commands_exports).map(
     (c) => handlerWrapper(c)
   );
-  return yargs_default(hideBin(process13.argv)).version("3.2.1").strict().command(commandModules).demandCommand();
+  return yargs_default(hideBin(process13.argv)).version("3.2.1").strict().command(commandModules).demandCommand().help();
 };
 var parseArgs_default = parseArgs;
 var parseConfig = () => {

--- a/deno.lock
+++ b/deno.lock
@@ -25,7 +25,7 @@
     "npm:@apeleghq/rfc8188@*": "1.0.7",
     "npm:@apeleghq/rfc8188@1.0.7": "1.0.7",
     "npm:@chelonia/crypto@*": "1.0.1",
-    "npm:@chelonia/lib@*": "1.2.7_@sbp+sbp@2.4.1",
+    "npm:@chelonia/lib@*": "1.2.9_@sbp+sbp@2.4.1",
     "npm:@chelonia/lib@1.2.7": "1.2.7_@sbp+sbp@2.4.1",
     "npm:@chelonia/lib@1.2.9": "1.2.9_@sbp+sbp@2.4.1",
     "npm:@chelonia/serdes@1.0.0": "1.0.0",
@@ -60,11 +60,11 @@
     "npm:redis@5.9.0": "5.9.0_@redis+client@5.9.0",
     "npm:rimraf@3.0.2": "3.0.2",
     "npm:smol-toml@1.4.2": "1.4.2",
-    "npm:tar@6.2.1": "6.2.1",
+    "npm:tar@7.5.7": "7.5.7",
     "npm:three@0.151.3": "0.151.3",
     "npm:turtledash@1.0.3": "1.0.3",
     "npm:tweetnacl@1.0.3": "1.0.3",
-    "npm:typescript-eslint@8.37.0": "8.37.0_eslint@9.39.0_typescript@5.8.3_@typescript-eslint+parser@8.37.0__eslint@9.39.0__typescript@5.8.3",
+    "npm:typescript-eslint@8.37.0": "8.37.0_eslint@9.31.0_typescript@5.8.3_@typescript-eslint+parser@8.37.0__eslint@9.31.0__typescript@5.8.3",
     "npm:uuid@9.0.0": "9.0.0",
     "npm:vue-clickaway@2.2.2": "2.2.2_vue@2.7.16",
     "npm:vue-router@3.6.5": "3.6.5",
@@ -507,14 +507,7 @@
     "@eslint-community/eslint-utils@4.9.0_eslint@9.31.0": {
       "integrity": "sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==",
       "dependencies": [
-        "eslint@9.31.0",
-        "eslint-visitor-keys@3.4.3"
-      ]
-    },
-    "@eslint-community/eslint-utils@4.9.0_eslint@9.39.0": {
-      "integrity": "sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==",
-      "dependencies": [
-        "eslint@9.39.0",
+        "eslint",
         "eslint-visitor-keys@3.4.3"
       ]
     },
@@ -532,20 +525,8 @@
     "@eslint/config-helpers@0.3.1": {
       "integrity": "sha512-xR93k9WhrDYpXHORXpxVL5oHj3Era7wo6k/Wd8/IsQNnZUTzkGS29lyn3nAT05v6ltUuTFVCCYDEGfy2Or/sPA=="
     },
-    "@eslint/config-helpers@0.4.2": {
-      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
-      "dependencies": [
-        "@eslint/core@0.17.0"
-      ]
-    },
     "@eslint/core@0.15.2": {
       "integrity": "sha512-78Md3/Rrxh83gCxoUc0EiciuOHsIITzLy53m3d9UyiW8y9Dj2D29FeETqyKA+BRK76tnTp6RXWb3pCay8Oyomg==",
-      "dependencies": [
-        "@types/json-schema"
-      ]
-    },
-    "@eslint/core@0.17.0": {
-      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
       "dependencies": [
         "@types/json-schema"
       ]
@@ -567,23 +548,13 @@
     "@eslint/js@9.31.0": {
       "integrity": "sha512-LOm5OVt7D4qiKCqoiPbA7LWmI+tbw1VbTUowBcUMgQSuM6poJufkFkYDcQpo5KfgD39TnNySV26QjOh7VFpSyw=="
     },
-    "@eslint/js@9.39.0": {
-      "integrity": "sha512-BIhe0sW91JGPiaF1mOuPy5v8NflqfjIcDNpC+LbW9f609WVRX1rArrhi6Z2ymvrAry9jw+5POTj4t2t62o8Bmw=="
-    },
     "@eslint/object-schema@2.1.7": {
       "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA=="
     },
     "@eslint/plugin-kit@0.3.5": {
       "integrity": "sha512-Z5kJ+wU3oA7MMIqVR9tyZRtjYPr4OC004Q4Rw7pgOKUOKkJfZ3O24nz3WYfGRpMDNmcOi3TwQOmgm7B7Tpii0w==",
       "dependencies": [
-        "@eslint/core@0.15.2",
-        "levn"
-      ]
-    },
-    "@eslint/plugin-kit@0.4.1": {
-      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
-      "dependencies": [
-        "@eslint/core@0.17.0",
+        "@eslint/core",
         "levn"
       ]
     },
@@ -846,6 +817,12 @@
     "@humanwhocodes/retry@0.4.3": {
       "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ=="
     },
+    "@isaacs/fs-minipass@4.0.1": {
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "dependencies": [
+        "minipass"
+      ]
+    },
     "@nodelib/fs.scandir@2.1.5": {
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
       "dependencies": [
@@ -1091,7 +1068,7 @@
         "@types/yargs-parser"
       ]
     },
-    "@typescript-eslint/eslint-plugin@8.37.0_@typescript-eslint+parser@8.37.0__eslint@9.39.0__typescript@5.8.3_eslint@9.39.0_typescript@5.8.3": {
+    "@typescript-eslint/eslint-plugin@8.37.0_@typescript-eslint+parser@8.37.0__eslint@9.31.0__typescript@5.8.3_eslint@9.31.0_typescript@5.8.3": {
       "integrity": "sha512-jsuVWeIkb6ggzB+wPCsR4e6loj+rM72ohW6IBn2C+5NCvfUVY8s33iFPySSVXqtm5Hu29Ne/9bnA0JmyLmgenA==",
       "dependencies": [
         "@eslint-community/regexpp",
@@ -1100,7 +1077,7 @@
         "@typescript-eslint/type-utils",
         "@typescript-eslint/utils",
         "@typescript-eslint/visitor-keys",
-        "eslint@9.39.0",
+        "eslint",
         "graphemer",
         "ignore@7.0.5",
         "natural-compare",
@@ -1108,7 +1085,7 @@
         "typescript"
       ]
     },
-    "@typescript-eslint/parser@8.37.0_eslint@9.39.0_typescript@5.8.3": {
+    "@typescript-eslint/parser@8.37.0_eslint@9.31.0_typescript@5.8.3": {
       "integrity": "sha512-kVIaQE9vrN9RLCQMQ3iyRlVJpTiDUY6woHGb30JDkfJErqrQEmtdWH3gV0PBAfGZgQXoqzXOO0T3K6ioApbbAA==",
       "dependencies": [
         "@typescript-eslint/scope-manager",
@@ -1116,7 +1093,7 @@
         "@typescript-eslint/typescript-estree",
         "@typescript-eslint/visitor-keys",
         "debug@4.4.3",
-        "eslint@9.39.0",
+        "eslint",
         "typescript"
       ]
     },
@@ -1142,14 +1119,14 @@
         "typescript"
       ]
     },
-    "@typescript-eslint/type-utils@8.37.0_eslint@9.39.0_typescript@5.8.3": {
+    "@typescript-eslint/type-utils@8.37.0_eslint@9.31.0_typescript@5.8.3": {
       "integrity": "sha512-SPkXWIkVZxhgwSwVq9rqj/4VFo7MnWwVaRNznfQDc/xPYHjXnPfLWn+4L6FF1cAz6e7dsqBeMawgl7QjUMj4Ow==",
       "dependencies": [
         "@typescript-eslint/types",
         "@typescript-eslint/typescript-estree",
         "@typescript-eslint/utils",
         "debug@4.4.3",
-        "eslint@9.39.0",
+        "eslint",
         "ts-api-utils",
         "typescript"
       ]
@@ -1173,14 +1150,14 @@
         "typescript"
       ]
     },
-    "@typescript-eslint/utils@8.37.0_eslint@9.39.0_typescript@5.8.3": {
+    "@typescript-eslint/utils@8.37.0_eslint@9.31.0_typescript@5.8.3": {
       "integrity": "sha512-TSFvkIW6gGjN2p6zbXo20FzCABbyUAuq6tBvNRGsKdsSQ6a7rnV6ADfZ7f4iI3lIiXc4F4WWvtUfDw9CJ9pO5A==",
       "dependencies": [
-        "@eslint-community/eslint-utils@4.9.0_eslint@9.39.0",
+        "@eslint-community/eslint-utils",
         "@typescript-eslint/scope-manager",
         "@typescript-eslint/types",
         "@typescript-eslint/typescript-estree",
-        "eslint@9.39.0",
+        "eslint",
         "typescript"
       ]
     },
@@ -1415,8 +1392,8 @@
         "readdirp"
       ]
     },
-    "chownr@2.0.0": {
-      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ=="
+    "chownr@3.0.0": {
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g=="
     },
     "clean-css@4.2.4": {
       "integrity": "sha512-EJUDT7nDVFDvaQgAo2G/PJvxmp1o/c6iXLbswsBbUFXi1Nr+AjA2cKmfbKDMjMvzEe75g3P6JkaDDAKk96A85A==",
@@ -1681,59 +1658,19 @@
     "eslint@9.31.0": {
       "integrity": "sha512-QldCVh/ztyKJJZLr4jXNUByx3gR+TDYZCRXEktiZoUR3PGy4qCmSbkxcIle8GEwGpb5JBZazlaJ/CxLidXdEbQ==",
       "dependencies": [
-        "@eslint-community/eslint-utils@4.9.0_eslint@9.31.0",
+        "@eslint-community/eslint-utils",
         "@eslint-community/regexpp",
         "@eslint/config-array",
-        "@eslint/config-helpers@0.3.1",
-        "@eslint/core@0.15.2",
+        "@eslint/config-helpers",
+        "@eslint/core",
         "@eslint/eslintrc",
-        "@eslint/js@9.31.0",
-        "@eslint/plugin-kit@0.3.5",
+        "@eslint/js",
+        "@eslint/plugin-kit",
         "@humanfs/node",
         "@humanwhocodes/module-importer",
         "@humanwhocodes/retry",
         "@types/estree",
         "@types/json-schema",
-        "ajv",
-        "chalk@4.1.0",
-        "cross-spawn",
-        "debug@4.4.3",
-        "escape-string-regexp@4.0.0",
-        "eslint-scope",
-        "eslint-visitor-keys@4.2.1",
-        "espree",
-        "esquery",
-        "esutils",
-        "fast-deep-equal",
-        "file-entry-cache",
-        "find-up",
-        "glob-parent@6.0.2",
-        "ignore@5.3.2",
-        "imurmurhash",
-        "is-glob",
-        "json-stable-stringify-without-jsonify",
-        "lodash.merge",
-        "minimatch@3.1.2",
-        "natural-compare",
-        "optionator"
-      ],
-      "bin": true
-    },
-    "eslint@9.39.0": {
-      "integrity": "sha512-iy2GE3MHrYTL5lrCtMZ0X1KLEKKUjmK0kzwcnefhR66txcEmXZD2YWgR5GNdcEwkNx3a0siYkSvl0vIC+Svjmg==",
-      "dependencies": [
-        "@eslint-community/eslint-utils@4.9.0_eslint@9.39.0",
-        "@eslint-community/regexpp",
-        "@eslint/config-array",
-        "@eslint/config-helpers@0.4.2",
-        "@eslint/core@0.17.0",
-        "@eslint/eslintrc",
-        "@eslint/js@9.39.0",
-        "@eslint/plugin-kit@0.4.1",
-        "@humanfs/node",
-        "@humanwhocodes/module-importer",
-        "@humanwhocodes/retry",
-        "@types/estree",
         "ajv",
         "chalk@4.1.0",
         "cross-spawn",
@@ -1853,12 +1790,6 @@
     },
     "flatted@3.3.3": {
       "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg=="
-    },
-    "fs-minipass@2.1.0": {
-      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-      "dependencies": [
-        "minipass@3.3.6"
-      ]
     },
     "fs.realpath@1.0.0": {
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
@@ -2223,20 +2154,13 @@
         "brace-expansion@2.0.2"
       ]
     },
-    "minipass@3.3.6": {
-      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-      "dependencies": [
-        "yallist@4.0.0"
-      ]
+    "minipass@7.1.3": {
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="
     },
-    "minipass@5.0.0": {
-      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ=="
-    },
-    "minizlib@2.1.2": {
-      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+    "minizlib@3.1.0": {
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
       "dependencies": [
-        "minipass@3.3.6",
-        "yallist@4.0.0"
+        "minipass"
       ]
     },
     "mkdirp@1.0.4": {
@@ -2926,16 +2850,16 @@
     "sync-message-port@1.1.3": {
       "integrity": "sha512-GTt8rSKje5FilG+wEdfCkOcLL7LWqpMlr2c3LRuKt/YXxcJ52aGSbGBAdI4L3aaqfrBt6y711El53ItyH1NWzg=="
     },
-    "tar@6.2.1": {
-      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
+    "tar@7.5.7": {
+      "integrity": "sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==",
       "dependencies": [
+        "@isaacs/fs-minipass",
         "chownr",
-        "fs-minipass",
-        "minipass@5.0.0",
+        "minipass",
         "minizlib",
-        "mkdirp",
-        "yallist@4.0.0"
-      ]
+        "yallist@5.0.0"
+      ],
+      "deprecated": true
     },
     "thread-stream@2.7.0": {
       "integrity": "sha512-qQiRWsU/wvNolI6tbbCKd9iKaTnCXsTwVxhhKM6nctPdujTyztjlbUkUTUymidWcMnZ5pWR0ej4a0tjsW021vw==",
@@ -2979,14 +2903,14 @@
         "prelude-ls"
       ]
     },
-    "typescript-eslint@8.37.0_eslint@9.39.0_typescript@5.8.3_@typescript-eslint+parser@8.37.0__eslint@9.39.0__typescript@5.8.3": {
+    "typescript-eslint@8.37.0_eslint@9.31.0_typescript@5.8.3_@typescript-eslint+parser@8.37.0__eslint@9.31.0__typescript@5.8.3": {
       "integrity": "sha512-TnbEjzkE9EmcO0Q2zM+GE8NQLItNAJpMmED1BdgoBMYNdqMhzlbqfdSwiRlAzEK2pA9UzVW0gzaaIzXWg2BjfA==",
       "dependencies": [
         "@typescript-eslint/eslint-plugin",
         "@typescript-eslint/parser",
         "@typescript-eslint/typescript-estree",
         "@typescript-eslint/utils",
-        "eslint@9.39.0",
+        "eslint",
         "typescript"
       ]
     },
@@ -3099,8 +3023,8 @@
     "yallist@2.1.2": {
       "integrity": "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A=="
     },
-    "yallist@4.0.0": {
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    "yallist@5.0.0": {
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw=="
     },
     "yargs-parser@20.2.9": {
       "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="
@@ -3180,7 +3104,7 @@
     "packageJson": {
       "dependencies": [
         "npm:rimraf@3.0.2",
-        "npm:tar@6.2.1"
+        "npm:tar@7.5.7"
       ]
     },
     "members": {

--- a/deno.lock
+++ b/deno.lock
@@ -25,7 +25,7 @@
     "npm:@apeleghq/rfc8188@*": "1.0.7",
     "npm:@apeleghq/rfc8188@1.0.7": "1.0.7",
     "npm:@chelonia/crypto@*": "1.0.1",
-    "npm:@chelonia/lib@*": "1.2.9_@sbp+sbp@2.4.1",
+    "npm:@chelonia/lib@*": "1.2.7_@sbp+sbp@2.4.1",
     "npm:@chelonia/lib@1.2.7": "1.2.7_@sbp+sbp@2.4.1",
     "npm:@chelonia/lib@1.2.9": "1.2.9_@sbp+sbp@2.4.1",
     "npm:@chelonia/serdes@1.0.0": "1.0.0",
@@ -60,11 +60,11 @@
     "npm:redis@5.9.0": "5.9.0_@redis+client@5.9.0",
     "npm:rimraf@3.0.2": "3.0.2",
     "npm:smol-toml@1.4.2": "1.4.2",
-    "npm:tar@7.5.7": "7.5.7",
+    "npm:tar@6.2.1": "6.2.1",
     "npm:three@0.151.3": "0.151.3",
     "npm:turtledash@1.0.3": "1.0.3",
     "npm:tweetnacl@1.0.3": "1.0.3",
-    "npm:typescript-eslint@8.37.0": "8.37.0_eslint@9.31.0_typescript@5.8.3_@typescript-eslint+parser@8.37.0__eslint@9.31.0__typescript@5.8.3",
+    "npm:typescript-eslint@8.37.0": "8.37.0_eslint@9.39.0_typescript@5.8.3_@typescript-eslint+parser@8.37.0__eslint@9.39.0__typescript@5.8.3",
     "npm:uuid@9.0.0": "9.0.0",
     "npm:vue-clickaway@2.2.2": "2.2.2_vue@2.7.16",
     "npm:vue-router@3.6.5": "3.6.5",
@@ -507,7 +507,14 @@
     "@eslint-community/eslint-utils@4.9.0_eslint@9.31.0": {
       "integrity": "sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==",
       "dependencies": [
-        "eslint",
+        "eslint@9.31.0",
+        "eslint-visitor-keys@3.4.3"
+      ]
+    },
+    "@eslint-community/eslint-utils@4.9.0_eslint@9.39.0": {
+      "integrity": "sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==",
+      "dependencies": [
+        "eslint@9.39.0",
         "eslint-visitor-keys@3.4.3"
       ]
     },
@@ -525,8 +532,20 @@
     "@eslint/config-helpers@0.3.1": {
       "integrity": "sha512-xR93k9WhrDYpXHORXpxVL5oHj3Era7wo6k/Wd8/IsQNnZUTzkGS29lyn3nAT05v6ltUuTFVCCYDEGfy2Or/sPA=="
     },
+    "@eslint/config-helpers@0.4.2": {
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+      "dependencies": [
+        "@eslint/core@0.17.0"
+      ]
+    },
     "@eslint/core@0.15.2": {
       "integrity": "sha512-78Md3/Rrxh83gCxoUc0EiciuOHsIITzLy53m3d9UyiW8y9Dj2D29FeETqyKA+BRK76tnTp6RXWb3pCay8Oyomg==",
+      "dependencies": [
+        "@types/json-schema"
+      ]
+    },
+    "@eslint/core@0.17.0": {
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
       "dependencies": [
         "@types/json-schema"
       ]
@@ -548,13 +567,23 @@
     "@eslint/js@9.31.0": {
       "integrity": "sha512-LOm5OVt7D4qiKCqoiPbA7LWmI+tbw1VbTUowBcUMgQSuM6poJufkFkYDcQpo5KfgD39TnNySV26QjOh7VFpSyw=="
     },
+    "@eslint/js@9.39.0": {
+      "integrity": "sha512-BIhe0sW91JGPiaF1mOuPy5v8NflqfjIcDNpC+LbW9f609WVRX1rArrhi6Z2ymvrAry9jw+5POTj4t2t62o8Bmw=="
+    },
     "@eslint/object-schema@2.1.7": {
       "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA=="
     },
     "@eslint/plugin-kit@0.3.5": {
       "integrity": "sha512-Z5kJ+wU3oA7MMIqVR9tyZRtjYPr4OC004Q4Rw7pgOKUOKkJfZ3O24nz3WYfGRpMDNmcOi3TwQOmgm7B7Tpii0w==",
       "dependencies": [
-        "@eslint/core",
+        "@eslint/core@0.15.2",
+        "levn"
+      ]
+    },
+    "@eslint/plugin-kit@0.4.1": {
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+      "dependencies": [
+        "@eslint/core@0.17.0",
         "levn"
       ]
     },
@@ -817,12 +846,6 @@
     "@humanwhocodes/retry@0.4.3": {
       "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ=="
     },
-    "@isaacs/fs-minipass@4.0.1": {
-      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
-      "dependencies": [
-        "minipass"
-      ]
-    },
     "@nodelib/fs.scandir@2.1.5": {
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
       "dependencies": [
@@ -1068,7 +1091,7 @@
         "@types/yargs-parser"
       ]
     },
-    "@typescript-eslint/eslint-plugin@8.37.0_@typescript-eslint+parser@8.37.0__eslint@9.31.0__typescript@5.8.3_eslint@9.31.0_typescript@5.8.3": {
+    "@typescript-eslint/eslint-plugin@8.37.0_@typescript-eslint+parser@8.37.0__eslint@9.39.0__typescript@5.8.3_eslint@9.39.0_typescript@5.8.3": {
       "integrity": "sha512-jsuVWeIkb6ggzB+wPCsR4e6loj+rM72ohW6IBn2C+5NCvfUVY8s33iFPySSVXqtm5Hu29Ne/9bnA0JmyLmgenA==",
       "dependencies": [
         "@eslint-community/regexpp",
@@ -1077,7 +1100,7 @@
         "@typescript-eslint/type-utils",
         "@typescript-eslint/utils",
         "@typescript-eslint/visitor-keys",
-        "eslint",
+        "eslint@9.39.0",
         "graphemer",
         "ignore@7.0.5",
         "natural-compare",
@@ -1085,7 +1108,7 @@
         "typescript"
       ]
     },
-    "@typescript-eslint/parser@8.37.0_eslint@9.31.0_typescript@5.8.3": {
+    "@typescript-eslint/parser@8.37.0_eslint@9.39.0_typescript@5.8.3": {
       "integrity": "sha512-kVIaQE9vrN9RLCQMQ3iyRlVJpTiDUY6woHGb30JDkfJErqrQEmtdWH3gV0PBAfGZgQXoqzXOO0T3K6ioApbbAA==",
       "dependencies": [
         "@typescript-eslint/scope-manager",
@@ -1093,7 +1116,7 @@
         "@typescript-eslint/typescript-estree",
         "@typescript-eslint/visitor-keys",
         "debug@4.4.3",
-        "eslint",
+        "eslint@9.39.0",
         "typescript"
       ]
     },
@@ -1119,14 +1142,14 @@
         "typescript"
       ]
     },
-    "@typescript-eslint/type-utils@8.37.0_eslint@9.31.0_typescript@5.8.3": {
+    "@typescript-eslint/type-utils@8.37.0_eslint@9.39.0_typescript@5.8.3": {
       "integrity": "sha512-SPkXWIkVZxhgwSwVq9rqj/4VFo7MnWwVaRNznfQDc/xPYHjXnPfLWn+4L6FF1cAz6e7dsqBeMawgl7QjUMj4Ow==",
       "dependencies": [
         "@typescript-eslint/types",
         "@typescript-eslint/typescript-estree",
         "@typescript-eslint/utils",
         "debug@4.4.3",
-        "eslint",
+        "eslint@9.39.0",
         "ts-api-utils",
         "typescript"
       ]
@@ -1150,14 +1173,14 @@
         "typescript"
       ]
     },
-    "@typescript-eslint/utils@8.37.0_eslint@9.31.0_typescript@5.8.3": {
+    "@typescript-eslint/utils@8.37.0_eslint@9.39.0_typescript@5.8.3": {
       "integrity": "sha512-TSFvkIW6gGjN2p6zbXo20FzCABbyUAuq6tBvNRGsKdsSQ6a7rnV6ADfZ7f4iI3lIiXc4F4WWvtUfDw9CJ9pO5A==",
       "dependencies": [
-        "@eslint-community/eslint-utils",
+        "@eslint-community/eslint-utils@4.9.0_eslint@9.39.0",
         "@typescript-eslint/scope-manager",
         "@typescript-eslint/types",
         "@typescript-eslint/typescript-estree",
-        "eslint",
+        "eslint@9.39.0",
         "typescript"
       ]
     },
@@ -1392,8 +1415,8 @@
         "readdirp"
       ]
     },
-    "chownr@3.0.0": {
-      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g=="
+    "chownr@2.0.0": {
+      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ=="
     },
     "clean-css@4.2.4": {
       "integrity": "sha512-EJUDT7nDVFDvaQgAo2G/PJvxmp1o/c6iXLbswsBbUFXi1Nr+AjA2cKmfbKDMjMvzEe75g3P6JkaDDAKk96A85A==",
@@ -1658,19 +1681,59 @@
     "eslint@9.31.0": {
       "integrity": "sha512-QldCVh/ztyKJJZLr4jXNUByx3gR+TDYZCRXEktiZoUR3PGy4qCmSbkxcIle8GEwGpb5JBZazlaJ/CxLidXdEbQ==",
       "dependencies": [
-        "@eslint-community/eslint-utils",
+        "@eslint-community/eslint-utils@4.9.0_eslint@9.31.0",
         "@eslint-community/regexpp",
         "@eslint/config-array",
-        "@eslint/config-helpers",
-        "@eslint/core",
+        "@eslint/config-helpers@0.3.1",
+        "@eslint/core@0.15.2",
         "@eslint/eslintrc",
-        "@eslint/js",
-        "@eslint/plugin-kit",
+        "@eslint/js@9.31.0",
+        "@eslint/plugin-kit@0.3.5",
         "@humanfs/node",
         "@humanwhocodes/module-importer",
         "@humanwhocodes/retry",
         "@types/estree",
         "@types/json-schema",
+        "ajv",
+        "chalk@4.1.0",
+        "cross-spawn",
+        "debug@4.4.3",
+        "escape-string-regexp@4.0.0",
+        "eslint-scope",
+        "eslint-visitor-keys@4.2.1",
+        "espree",
+        "esquery",
+        "esutils",
+        "fast-deep-equal",
+        "file-entry-cache",
+        "find-up",
+        "glob-parent@6.0.2",
+        "ignore@5.3.2",
+        "imurmurhash",
+        "is-glob",
+        "json-stable-stringify-without-jsonify",
+        "lodash.merge",
+        "minimatch@3.1.2",
+        "natural-compare",
+        "optionator"
+      ],
+      "bin": true
+    },
+    "eslint@9.39.0": {
+      "integrity": "sha512-iy2GE3MHrYTL5lrCtMZ0X1KLEKKUjmK0kzwcnefhR66txcEmXZD2YWgR5GNdcEwkNx3a0siYkSvl0vIC+Svjmg==",
+      "dependencies": [
+        "@eslint-community/eslint-utils@4.9.0_eslint@9.39.0",
+        "@eslint-community/regexpp",
+        "@eslint/config-array",
+        "@eslint/config-helpers@0.4.2",
+        "@eslint/core@0.17.0",
+        "@eslint/eslintrc",
+        "@eslint/js@9.39.0",
+        "@eslint/plugin-kit@0.4.1",
+        "@humanfs/node",
+        "@humanwhocodes/module-importer",
+        "@humanwhocodes/retry",
+        "@types/estree",
         "ajv",
         "chalk@4.1.0",
         "cross-spawn",
@@ -1790,6 +1853,12 @@
     },
     "flatted@3.3.3": {
       "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg=="
+    },
+    "fs-minipass@2.1.0": {
+      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+      "dependencies": [
+        "minipass@3.3.6"
+      ]
     },
     "fs.realpath@1.0.0": {
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
@@ -2154,13 +2223,20 @@
         "brace-expansion@2.0.2"
       ]
     },
-    "minipass@7.1.3": {
-      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="
-    },
-    "minizlib@3.1.0": {
-      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+    "minipass@3.3.6": {
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
       "dependencies": [
-        "minipass"
+        "yallist@4.0.0"
+      ]
+    },
+    "minipass@5.0.0": {
+      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ=="
+    },
+    "minizlib@2.1.2": {
+      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+      "dependencies": [
+        "minipass@3.3.6",
+        "yallist@4.0.0"
       ]
     },
     "mkdirp@1.0.4": {
@@ -2850,16 +2926,16 @@
     "sync-message-port@1.1.3": {
       "integrity": "sha512-GTt8rSKje5FilG+wEdfCkOcLL7LWqpMlr2c3LRuKt/YXxcJ52aGSbGBAdI4L3aaqfrBt6y711El53ItyH1NWzg=="
     },
-    "tar@7.5.7": {
-      "integrity": "sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==",
+    "tar@6.2.1": {
+      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
       "dependencies": [
-        "@isaacs/fs-minipass",
         "chownr",
-        "minipass",
+        "fs-minipass",
+        "minipass@5.0.0",
         "minizlib",
-        "yallist@5.0.0"
-      ],
-      "deprecated": true
+        "mkdirp",
+        "yallist@4.0.0"
+      ]
     },
     "thread-stream@2.7.0": {
       "integrity": "sha512-qQiRWsU/wvNolI6tbbCKd9iKaTnCXsTwVxhhKM6nctPdujTyztjlbUkUTUymidWcMnZ5pWR0ej4a0tjsW021vw==",
@@ -2903,14 +2979,14 @@
         "prelude-ls"
       ]
     },
-    "typescript-eslint@8.37.0_eslint@9.31.0_typescript@5.8.3_@typescript-eslint+parser@8.37.0__eslint@9.31.0__typescript@5.8.3": {
+    "typescript-eslint@8.37.0_eslint@9.39.0_typescript@5.8.3_@typescript-eslint+parser@8.37.0__eslint@9.39.0__typescript@5.8.3": {
       "integrity": "sha512-TnbEjzkE9EmcO0Q2zM+GE8NQLItNAJpMmED1BdgoBMYNdqMhzlbqfdSwiRlAzEK2pA9UzVW0gzaaIzXWg2BjfA==",
       "dependencies": [
         "@typescript-eslint/eslint-plugin",
         "@typescript-eslint/parser",
         "@typescript-eslint/typescript-estree",
         "@typescript-eslint/utils",
-        "eslint",
+        "eslint@9.39.0",
         "typescript"
       ]
     },
@@ -3023,8 +3099,8 @@
     "yallist@2.1.2": {
       "integrity": "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A=="
     },
-    "yallist@5.0.0": {
-      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw=="
+    "yallist@4.0.0": {
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yargs-parser@20.2.9": {
       "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="
@@ -3104,7 +3180,7 @@
     "packageJson": {
       "dependencies": [
         "npm:rimraf@3.0.2",
-        "npm:tar@7.5.7"
+        "npm:tar@6.2.1"
       ]
     },
     "members": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@chelonia/cli",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@chelonia/cli",
-      "version": "3.2.0",
+      "version": "3.2.1",
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "dependencies": {
@@ -15,8 +15,7 @@
       },
       "bin": {
         "chel": "bin/chel"
-      },
-      "devDependencies": {}
+      }
     },
     "node_modules/@isaacs/fs-minipass": {
       "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chelonia/cli",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "Chelonia Command-line Interface",
   "main": "src/main.ts",
   "scripts": {

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -18,7 +18,7 @@ type Params = {
   out?: string;
   slim?: string;
   name?: string;
-  version?: string;
+  contractVersion?: string;
   signingKey: string;
   contractBundle: string;
 }
@@ -41,7 +41,7 @@ export async function manifest (args: ArgumentsCamelCase<Params>): Promise<void>
   const parsedFilepath = path.parse(contractFile)
   const { name: contractFileName, base: contractBasename, dir: contractDir } = parsedFilepath
   const name = args.name || contractFileName
-  const version = args.version || 'x'
+  const version = args.contractVersion || 'x'
   const slim = args.slim
   const outFile: string = args.out || path.join(contractDir, `${contractFileName}.${version}.manifest.json`)
   if (!keyFile) exit('Missing signing key file')
@@ -133,12 +133,12 @@ export const module = {
         string: true
       })
       .alias('s', 'slim')
-      .option('version', {
+      .option('contract-version', {
         describe: 'Contract version',
         requiresArg: true,
         string: true
       })
-      .alias('v', 'version')
+      .alias('V', 'contract-version')
       .positional('signingKey', {
         describe: 'Signing key file',
         demandOption: true,
@@ -150,7 +150,7 @@ export const module = {
         type: 'string'
       })
   },
-  command: 'manifest [-k|--key <pubkey1>] [-k|--key <pubkey2> ...] [--out <manifest.json>] [-s|--slim <contract-slim.js>] [-v|--version <version>] <signingKey> <contractBundle>',
+  command: 'manifest [-k|--key <pubkey1>] [-k|--key <pubkey2> ...] [--out <manifest.json>] [-s|--slim <contract-slim.js>] [-V|--contract-version <version>] <signingKey> <contractBundle>',
   describe: 'Produce a signed manifest from a contract.\n' + 'If unspecified, <version> is set to \'x\'.',
   postHandler: (argv) => {
     return manifest(argv)

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -1,4 +1,4 @@
-// chel manifest [-k|--key <pubkey1> [-k|--key <pubkey2> ...]] [--out=<manifest.json>] [-s|--slim <contract-slim.js>] [-v|--version <version>] <key.json> <contract-bundle.js>
+// chel manifest [-k|--key <pubkey1>] [-k|--key <pubkey2> ...] [--out=<manifest.json>] [-s|--slim <contract-slim.js>] [-V|--contract-version <version>] <key.json> <contract-bundle.js>
 
 // TODO: consider a --copy-files option that works with --out which copies version-stamped
 //       contracts to the same folder as --out.

--- a/src/parseArgs.ts
+++ b/src/parseArgs.ts
@@ -30,7 +30,6 @@ const parseArgs = () => {
     .strict()
     .command(commandModules)
     .demandCommand()
-    .help()
 }
 
 export default parseArgs

--- a/src/parseArgs.ts
+++ b/src/parseArgs.ts
@@ -30,6 +30,7 @@ const parseArgs = () => {
     .strict()
     .command(commandModules)
     .demandCommand()
+    .help()
 }
 
 export default parseArgs


### PR DESCRIPTION
This fixes an important issue with `chel manifest`. Apparently, `yargs` (unless this is disabled) will add a `--version / v` option. This is fine, but it doesn't allow it to be overridden by commands. The result is that `chel manifest` will always consider the version as unspecified.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/okturtles/chel/pull/126" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
