### PR TITLE
Fix MessagePort leaks

### DIFF
--- a/src/serve/createWorker.ts
+++ b/src/serve/createWorker.ts
@@ -52,6 +52,15 @@ const createWorker = (path: string): WorkerType => {
             })
           }, false)
           resolve()
+        } else if (msg && typeof msg === 'object' && msg.type === 'init-error') {
+          // Worker initialization failed. Reject the `ready` promise so server
+          // startup fails loudly instead of silently proceeding with a
+          // half-initialized worker, and terminate the broken worker to avoid
+          // leaking it. See `signalInitError` in genericWorker.ts.
+          worker.removeEventListener('message', msgHandler, false)
+          worker.removeEventListener('error', reject, { capture: false })
+          worker.terminate()
+          reject(new Error(`Worker ${basename(path)} failed to initialize: ${String((msg as { error?: string }).error)}`))
         } else if (msg && typeof msg === 'object' && msg.type === 'sbp' && Array.isArray(msg.data) && String(msg.data[0]).startsWith('chelonia.db/')) {
           const port = msg.port
           Promise.try(() => sbp(...(deserializer(msg.data)) as [string, ...unknown[]])).then((r) => {

--- a/src/serve/creditsWorker.ts
+++ b/src/serve/creditsWorker.ts
@@ -1,6 +1,6 @@
 import sbp from 'npm:@sbp/sbp'
 import { CREDITS_WORKER_TASK_TIME_INTERVAL as TASK_TIME_INTERVAL } from './constants.ts'
-import { readyQueueName } from './genericWorker.ts'
+import { readyQueueName, signalReady, signalInitError } from './genericWorker.ts'
 
 // Type definitions for credit history entries
 interface GranularHistoryEntryBase {
@@ -187,7 +187,16 @@ const updateCredits = async (billableEntity: string, type: 'credit' | 'charge', 
   })
 }
 
-sbp('okTurtles.eventQueue/queueEvent', readyQueueName, () => setTimeout(sbp, TASK_TIME_INTERVAL, 'worker/computeCredits'))
+sbp('okTurtles.eventQueue/queueEvent', readyQueueName, () => {
+  try {
+    setTimeout(sbp, TASK_TIME_INTERVAL, 'worker/computeCredits')
+    // Signal ready only after init completes. See `signalReady` in
+    // genericWorker.ts for why ordering matters.
+    signalReady()
+  } catch (e) {
+    signalInitError(e)
+  }
+})
 
 sbp('sbp/selectors/register', {
   'worker/computeCredits': async () => {

--- a/src/serve/genericWorker.ts
+++ b/src/serve/genericWorker.ts
@@ -86,6 +86,34 @@ self.addEventListener('message', (ev) => {
   })
 })
 
-sbp('okTurtles.eventQueue/queueEvent', readyQueueName, () => {
-  self.postMessage('ready')
-})
+// Signals to the main thread that the worker is fully initialized and ready
+// to handle RPC calls. This MUST be called by each concrete worker at the end
+// of a *successful* init task — not at module load time, and not from a
+// `finally` block. If `ready` is posted before init completes, the main thread
+// treats the worker as usable and may terminate it while init-era `rpc()`
+// MessagePorts are still in flight on the worker->main message channel. Those
+// ports were already transferred out of the worker (so it can't close them)
+// but never reached the main thread's `msgHandler` (so it can't close them
+// either), leaving them orphaned and triggering Deno's resource sanitizer
+// leak detector. On init failure, call `signalInitError` instead so the main
+// thread rejects the `ready` promise and fails loudly rather than silently
+// proceeding with a half-initialized worker.
+export const signalReady = () => {
+  sbp('okTurtles.eventQueue/queueEvent', readyQueueName, () => {
+    self.postMessage('ready')
+  })
+}
+
+// Signals an initialization failure to the main thread. The main thread
+// rejects the worker's `ready` promise with the supplied error (and terminates
+// the worker), causing server startup to fail rather than silently proceeding
+// with a half-initialized worker. Use this in the `catch` block of a worker's
+// init task.
+export const signalInitError = (e: unknown) => {
+  sbp('okTurtles.eventQueue/queueEvent', readyQueueName, () => {
+    self.postMessage({
+      type: 'init-error',
+      error: e instanceof Error ? e.message : String(e)
+    })
+  })
+}

--- a/src/serve/ownerSizeTotalWorker.ts
+++ b/src/serve/ownerSizeTotalWorker.ts
@@ -1,7 +1,7 @@
 import sbp from 'npm:@sbp/sbp'
 import { OWNER_SIZE_TOTAL_WORKER_TASK_TIME_INTERVAL as TASK_TIME_INTERVAL } from './constants.ts'
 import { appendToIndexFactory, lookupUltimateOwner, removeFromIndexFactory, updateSize } from './db-utils.ts'
-import { readyQueueName } from './genericWorker.ts'
+import { readyQueueName, signalReady, signalInitError } from './genericWorker.ts'
 
 // This file defines two different methods for doing size computations:
 // `backend/server/computeSizeTaskDeltas` and `backend/server/computeSizeTask`.
@@ -74,27 +74,39 @@ const removeFromTempIndex = (cids: string[]) => {
  * previous unclean shutdown).
  */
 sbp('okTurtles.eventQueue/queueEvent', readyQueueName, async () => {
-  // Iterate through all 256 possible bucket keys.
-  for (let i = 0; i < 256; i++) {
-    // Fetch the content of the bucket
-    // (bypassCache isn't really needed here as the cache should be empty, but
-    // it's added for clarity.)
-    const data = await sbp('chelonia.db/get', `_private_pendingIdx_ownerTotalSize_${i}`, { bypassCache: true })
-    if (data) {
-      // Split the string and add mark each CID as requiring full recalculation
-      (data as string).split('\x00').forEach((cid: string) => {
-        updatedSizeList.add(cid)
-      })
+  try {
+    // Iterate through all 256 possible bucket keys.
+    for (let i = 0; i < 256; i++) {
+      // Fetch the content of the bucket
+      // (bypassCache isn't really needed here as the cache should be empty, but
+      // it's added for clarity.)
+      const data = await sbp('chelonia.db/get', `_private_pendingIdx_ownerTotalSize_${i}`, { bypassCache: true })
+      if (data) {
+        // Split the string and add mark each CID as requiring full recalculation
+        (data as string).split('\x00').forEach((cid: string) => {
+          updatedSizeList.add(cid)
+        })
+      }
     }
-  }
 
-  console.info(`[ownerSizeTotalWorker] Loaded ${updatedSizeList.size} CIDs for full recalculation.`)
-  if (updatedSizeList.size) {
-    sbp('backend/server/computeSizeTask')
-  }
+    console.info(`[ownerSizeTotalWorker] Loaded ${updatedSizeList.size} CIDs for full recalculation.`)
+    if (updatedSizeList.size) {
+      sbp('backend/server/computeSizeTask')
+    }
 
-  // Schedule the recurring delta computation task
-  setTimeout(sbp, TASK_TIME_INTERVAL, 'backend/server/computeSizeTaskDeltas')
+    // Schedule the recurring delta computation task
+    setTimeout(sbp, TASK_TIME_INTERVAL, 'backend/server/computeSizeTaskDeltas')
+    // Signal ready only after init completes successfully. This must run
+    // after the 256 init DB calls so their `rpc()` MessagePorts are fully
+    // drained and closed on the main thread before `ready` fires. See
+    // `signalReady` in genericWorker.ts for the full rationale.
+    signalReady()
+  } catch (e) {
+    console.error('[ownerSizeTotalWorker] Initialization error:', e)
+    // Surface the failure so server startup fails loudly instead of silently
+    // proceeding with a half-initialized worker.
+    signalInitError(e)
+  }
 })
 
 sbp('sbp/selectors/register', {


### PR DESCRIPTION
This PR addresses a transient issue when running tests by ensuring to open ports are leaked.

These are the errors that previously occurred:

```
 ERRORS 

routes: stateless endpoints => ./src/serve/routes-stateless.test.ts:4:6
error: Leaks detected:
  - A message port was created during the test, but not closed during the test. Close the message port by calling `messagePort.close()`.

routes: ZKPP endpoints => ./src/serve/routes-zkpp.test.ts:94:6
error: Leaks detected:
  - A message port was created during the test, but not closed during the test. Close the message port by calling `messagePort.close()`.

 FAILURES 

routes: stateless endpoints => ./src/serve/routes-stateless.test.ts:4:6
routes: ZKPP endpoints => ./src/serve/routes-zkpp.test.ts:94:6

FAILED | 12 passed (136 steps) | 2 failed (4s)

```

AI disclosure: This PR was made with the assistance of GLM-5.2.