### PR TITLE
Build improvements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,7 +88,7 @@ scripts/
 ├── sync-versions.ts     # Keeps optionalDependencies in sync (version hook)
 ├── dashboard-esbuild.ts # Dashboard UI bundling
 ├── lint.ts              # ESLint wrapper
-└── dist.ts              # Distribution script (TODO)
+└── dist.ts              # Inert placeholder; `deno task dist` is defined in deno.json
 
 test/
 ├── assets/              # Test fixtures (keys, manifests, contracts)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ All commands are run via Deno tasks defined in `deno.json`:
 deno task lint            # Lint the codebase
 deno task test            # Run tests
 deno task build           # Build the project (outputs to build/)
-deno task compile         # Compile native binaries for multiple platforms (outputs to dist/)
+deno task compile         # Native binaries + release tarballs (outputs to dist/)
 deno task dist            # Full distribution (lint + build + compile)
 deno task chel -- <args>  # Run the CLI locally (lint + build + execute)
 ```
@@ -80,7 +80,12 @@ src/
 
 scripts/
 ├── build.ts             # esbuild bundling
-├── compile.ts           # Deno compile for native binaries
+├── binaries.ts          # Shared, content-addressed native binary cache
+├── compile.ts           # Release tarballs (reproducible .tar.gz + checksums)
+├── publish.ts           # npm platform sub-packages (prepublishOnly hook)
+├── targets.ts           # Supported platforms + `deno compile` invocation
+├── paths.ts             # Shared build/release artifact paths
+├── sync-versions.ts     # Keeps optionalDependencies in sync (version hook)
 ├── dashboard-esbuild.ts # Dashboard UI bundling
 ├── lint.ts              # ESLint wrapper
 └── dist.ts              # Distribution script (TODO)
@@ -320,7 +325,12 @@ These are version controlled to catch bugs or vulnerabilities in the transpilati
 
 ## Release Process
 
-1. Update version in `package.json`
-2. Run `deno task dist` to build and compile binaries
-3. Binaries output to `dist/chel-v<version>-<arch>.tar.gz`
-4. SHA256 checksums printed for verification
+1. `npm version <patch|minor|major>` (rebuilds and commits the bundle)
+2. `deno task dist` to compile the binaries and pack the release tarballs
+   (`dist/chel-v<version>-<target>.tar.gz`, SHA256 checksums printed)
+3. `git diff --exit-code -- build` to confirm the rebuild is reproducible
+4. `npm publish --access public`, which reuses the binaries from step 2
+   instead of compiling its own copies
+
+See the Packaging section of README.md for the full procedure and for how the
+binary cache decides what can be reused.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -299,10 +299,6 @@ Manifests are JSON with signed body:
 }
 ```
 
-### 9. dist/ under version control, ignore it!
-
-These are version controlled to catch bugs or vulnerabilities in the transpilation process, but they are not intended for review unless there is a vulnerability introduced that's not found in src/.
-
 ## Key Dependencies
 
 - `@sbp/sbp` - Selector-based programming / dependency injection

--- a/README.md
+++ b/README.md
@@ -511,12 +511,10 @@ Steps to publish a new release of `@chelonia/cli` to npm:
    ```
 
    If your account uses 2FA, `npm publish` may prompt for authentication.
-   Do not rely on `--otp=<code>`: the publish step compiles all five native
-   binaries before publishing the first sub-package. Compilation is usually
-   fast but can take several minutes, so a TOTP code entered at the start
-   will likely have expired by the time the first `npm publish` runs.
-   Complete the browser-based authentication flow when prompted, or use a
-   granular automation token instead.
+   Do not rely on `--otp=<code>`: a TOTP code entered at the start of the
+   release may well have expired by the time the first sub-package is
+   published. Complete the browser-based authentication flow when prompted,
+   or use a granular automation token instead.
 
 2. **Bump the version:**
 
@@ -534,12 +532,28 @@ Steps to publish a new release of `@chelonia/cli` to npm:
 
    As a result, the version commit and tag contain the up-to-date bundle and
    the working directory stays clean. The publish step verifies that what it
-   compiles is exactly this committed bundle and refuses to run otherwise.
+   ships is exactly this committed bundle and refuses to run otherwise.
    This also guarantees the maintainer rebuilds the bundle on `master`
    (merged PRs can each produce a correct bundle individually, yet the
    combined result on `master` may still differ).
 
-3. **Publish:**
+3. **Build the release artifacts** (the tarballs for the GitHub release):
+
+   ```bash
+   deno task dist
+   git diff --exit-code -- build   # fails if the rebuild diverged from the tag
+   ```
+
+   This lints, rebuilds the bundle, compiles one native binary per supported
+   platform, and packs each one into `dist/chel-v<version>-<target>.tar.gz`,
+   printing SHA256 checksums.
+
+   The `git diff --exit-code -- build` afterwards confirms the rebuild is
+   byte-identical to the version commit, i.e. that the build is reproducible.
+   It also has to pass before publishing, since the next step requires a clean
+   `build/`. If it fails, do not publish: investigate the divergence first.
+
+4. **Publish:**
 
    ```bash
    npm publish --access public
@@ -550,8 +564,11 @@ Steps to publish a new release of `@chelonia/cli` to npm:
    - Verifies that the committed bundle matches `package.json` (via
      `build/version.json`) and that the working tree is clean for `build/`
      and `package.json`, refusing to publish otherwise
-   - Compiles a native binary for each supported platform from the committed
-     `build/` bundle (the bundle is *not* rebuilt here)
+   - Reuses the native binaries from step 3 instead of compiling its own
+     copies, so a release compiles each binary once and npm and GitHub are
+     guaranteed to ship identical bytes. If a binary is missing, or was built
+     from a different bundle, it is compiled here instead — publishing without
+     step 3 works, it just takes several minutes longer
    - Creates and publishes a platform sub-package (`@chelonia/cli-<arch>-<os>`) for each target
    - Reconciles `optionalDependencies` as a final safety check
 
@@ -559,25 +576,27 @@ Steps to publish a new release of `@chelonia/cli` to npm:
    main `@chelonia/cli` package, whose `optionalDependencies` now point to the
    freshly published sub-packages.
 
-4. **Generate the release tarballs** (for the GitHub release):
-
-   ```bash
-   deno task dist
-   git diff --exit-code -- build   # fails if the rebuild diverged from the tag
-   ```
-
-   This lints, builds, and compiles native binaries into
-   `dist/chel-v<version>-<target>.tar.gz`, printing SHA256 checksums. It must
-   run *after* `npm publish`: `deno task dist` rebuilds `build/`, which might
-   dirty the working tree that the publish verification requires to be clean.
-   The `git diff --exit-code -- build` afterwards confirms the rebuild is
-   byte-identical to the version commit, i.e. that the build is reproducible.
-
 5. **Push the version commit and tag:**
 
    ```bash
    git push && git push --tags
    ```
+
+### Build caching
+
+Compiling the five native binaries is by far the slowest part of a release, so
+the tarballs and the npm sub-packages share one set of them, kept under the
+gitignored `dist/` directory. `deno task dist` remains usable on its own, at
+any time, to produce the tarballs without publishing anything.
+
+Reuse is decided by content, not timestamps: each artifact is stamped with a
+fingerprint of everything the binary embeds (all of `build/`), plus the Deno
+version and the compile flags. Any change to the bundle, a Deno upgrade, or a
+change to the compile flags therefore recompiles automatically, while
+re-running `deno task dist` with nothing changed does no work at all. An
+interrupted or failed run never leaves a half-built artifact looking current.
+To rebuild everything from scratch anyway, set `CHEL_FORCE_COMPILE=1` or delete
+`dist/`.
 
 ## History
 

--- a/README.md
+++ b/README.md
@@ -484,6 +484,22 @@ When you install `@chelonia/cli`, npm automatically selects the correct
 sub-package for your platform via `optionalDependencies`. Windows arm64 is
 currently **not** supported.
 
+The `chel` command itself is always provided by the main `@chelonia/cli`
+package, which ships a small launcher that spawns the native binary from the
+sub-package npm selected. The sub-packages intentionally declare no command of
+their own: if they did, they would compete with the main package for the same
+`chel` entry in `node_modules/.bin`, and npm would end up wiring `chel` to a
+bare platform binary (or to nothing at all when the main package is the project
+root). Because npm therefore never adjusts the binary's permissions at install
+time, the executable bit is baked into the published sub-package instead.
+
+This layout is verified against npm 10, pnpm (both its isolated and hoisted
+layouts), Yarn 1, and Yarn 4 (both Plug'n'Play and `node-modules`), for local
+and global installs. If `chel` cannot start, the launcher explains why rather
+than printing a stack trace: exit code 127 means no sub-package for your
+platform is installed, and 126 means one was found but its binary is missing or
+not executable (reinstall with `npm install --force @chelonia/cli`).
+
 ## Packaging
 
 Steps to publish a new release of `@chelonia/cli` to npm:

--- a/bin/chel.js
+++ b/bin/chel.js
@@ -8,6 +8,10 @@
 // resolves the platform sub-package selected by npm and spawns its native
 // binary, forwarding all arguments and stdio.
 //
+// The sub-packages deliberately declare no `bin` of their own: doing so would
+// make them fight the root package for the `chel` link inside
+// `node_modules/.bin`. See BINARY_FIELD in scripts/targets.ts.
+//
 // The sub-package naming convention `@chelonia/cli-<arch>-<platform>` matches
 // `subPackageName` in scripts/targets.ts, where <arch> is `process.arch`
 // ('x64' | 'arm64') and <platform> is `process.platform`
@@ -19,6 +23,7 @@
 const { spawn } = require('node:child_process')
 const path = require('node:path')
 const os = require('node:os')
+const fs = require('node:fs')
 
 // Translate the child's (code, signal) into a POSIX-conformant exit status:
 // 128 + signum when killed by a signal (130 for SIGINT, 143 for SIGTERM), so
@@ -47,15 +52,36 @@ try {
 }
 
 const subPkg = require(pkgJsonPath)
-const binRel = typeof subPkg.bin === 'string'
-  ? subPkg.bin
-  : subPkg.bin && (subPkg.bin.chel || Object.values(subPkg.bin)[0])
-if (!binRel) {
-  console.error(`chel: '${subPkgName}' does not declare a binary`)
-  process.exit(1)
-}
+// Sub-packages advertise their binary under `chelBinary` rather than `bin`, so
+// that npm links the name `chel` for this package only (see BINARY_FIELD in
+// scripts/targets.ts). The platform-derived fallback keeps the shim working
+// with sub-packages that predate that field, and is pinned by
+// scripts/targets.test.ts against the filenames in TARGETS.
+const binRel = typeof subPkg.chelBinary === 'string' && subPkg.chelBinary
+  ? subPkg.chelBinary
+  : (process.platform === 'win32' ? 'chel.exe' : 'chel')
 
 const binPath = path.join(path.dirname(pkgJsonPath), binRel)
+
+// Check the binary before spawning so a broken install reports something
+// actionable instead of a raw ENOENT/EACCES stack trace. This is worth doing
+// explicitly because the sub-package declares no `bin`, so npm never touches
+// the file's permissions at install time: the executable bit comes from the
+// published tarball, and a package manager or filesystem that drops it would
+// otherwise fail here in a confusing way.
+try {
+  fs.accessSync(binPath, fs.constants.X_OK)
+} catch (err) {
+  const reason = err.code === 'ENOENT'
+    ? 'the file is missing'
+    : (err.code === 'EACCES' ? 'the file is not executable' : `cannot run it (${err.code})`)
+  console.error(
+    `chel: found '${subPkgName}' but ${reason}: ${binPath}\n` +
+    `Try reinstalling: npm install --force @chelonia/cli`
+  )
+  process.exit(126)
+}
+
 const child = spawn(binPath, process.argv.slice(2), { stdio: 'inherit' })
 
 // Track whether the child has actually exited, so we keep forwarding repeat

--- a/bin/chel.js
+++ b/bin/chel.js
@@ -73,10 +73,12 @@ try {
   fs.accessSync(binPath, fs.constants.X_OK)
 } catch (err) {
   const reason = err.code === 'ENOENT'
-    ? 'the file is missing'
-    : (err.code === 'EACCES' ? 'the file is not executable' : `cannot run it (${err.code})`)
+    ? 'its binary is missing'
+    : (err.code === 'EACCES'
+        ? 'its binary is not executable'
+        : `its binary cannot be run (${err.code})`)
   console.error(
-    `chel: found '${subPkgName}' but ${reason}: ${binPath}\n` +
+    `chel: platform package '${subPkgName}' is installed but ${reason}:\n  ${binPath}\n` +
     `Try reinstalling: npm install --force @chelonia/cli`
   )
   process.exit(126)

--- a/bin/chel.js
+++ b/bin/chel.js
@@ -105,9 +105,19 @@ for (const name of Object.keys(os.constants.signals)) {
   process.on(name, () => { if (!childExited) child.kill(name) })
 }
 
+// spawn can still fail after the pre-check passes (e.g. on Windows X_OK is
+// only an existence check, so a corrupt binary gets this far; on Unix a file
+// on a noexec mount or one open for writing passes accessSync but not
+// execve). Report that in the same style as the pre-check above, with the
+// same "found but cannot be run" exit code, instead of dumping the raw error
+// object and its stack trace.
 child.on('error', (err) => {
-  console.error('chel:', err)
-  process.exit(1)
+  console.error(
+    `chel: platform package '${subPkgName}' is installed but its binary ` +
+    `cannot be run (${err.code ?? 'unknown error'}):\n  ${binPath}\n` +
+    `Try reinstalling: npm install --force @chelonia/cli`
+  )
+  process.exit(126)
 })
 child.on('close', (code, signal) => {
   childExited = true

--- a/build/main.js
+++ b/build/main.js
@@ -2775,6 +2775,9 @@ var buf = Deno.UnsafePointerView.getArrayBuffer;
 var readCstr = Deno.UnsafePointerView.getCString;
 
 // deno:https://jsr.io/@db/sqlite/0.13.0/src/statement.ts
+var _computedKey;
+var _computedKey1;
+var _computedKey2;
 var { sqlite3_prepare_v2, sqlite3_reset, sqlite3_clear_bindings, sqlite3_step, sqlite3_column_count, sqlite3_column_type, sqlite3_column_value, sqlite3_value_subtype, sqlite3_column_text, sqlite3_finalize, sqlite3_column_int64, sqlite3_column_double, sqlite3_column_blob, sqlite3_column_bytes, sqlite3_column_name, sqlite3_expanded_sql, sqlite3_bind_parameter_count, sqlite3_bind_int, sqlite3_bind_int64, sqlite3_bind_text, sqlite3_bind_blob, sqlite3_bind_double, sqlite3_bind_parameter_index, sqlite3_sql, sqlite3_stmt_readonly, sqlite3_bind_parameter_name, sqlite3_changes, sqlite3_column_int } = ffi_default;
 var STATEMENTS_TO_DB = /* @__PURE__ */ new Map();
 var emptyStringBuffer = new Uint8Array(1);
@@ -2828,6 +2831,7 @@ function getColumn(handle, i2, int64, parseJson) {
     }
   }
 }
+_computedKey = Symbol.iterator, _computedKey1 = Symbol.dispose, _computedKey2 = Symbol.for("Deno.customInspect");
 var Statement = class {
   db;
   #handle;
@@ -3305,19 +3309,22 @@ var Statement = class {
     }
     sqlite3_reset(this.#handle);
   }
-  [Symbol.iterator]() {
+  [_computedKey]() {
     return this.iter();
   }
-  [Symbol.dispose]() {
+  [_computedKey1]() {
     this.finalize();
   }
-  [Symbol.for("Deno.customInspect")]() {
+  [_computedKey2]() {
     return `Statement { ${this.expandedSql} }`;
   }
 };
 
 // deno:https://jsr.io/@db/sqlite/0.13.0/src/blob.ts
+var _computedKey3;
+var _computedKey12;
 var { sqlite3_blob_open, sqlite3_blob_bytes, sqlite3_blob_close, sqlite3_blob_read, sqlite3_blob_write } = ffi_default;
+_computedKey3 = Symbol.iterator, _computedKey12 = Symbol.for("Deno.customInspect");
 var SQLBlob = class {
   #handle;
   constructor(db2, options2) {
@@ -3392,7 +3399,7 @@ var SQLBlob = class {
       }
     });
   }
-  *[Symbol.iterator]() {
+  *[_computedKey3]() {
     const length2 = this.byteLength;
     let offset = 0;
     while (offset < length2) {
@@ -3403,16 +3410,18 @@ var SQLBlob = class {
       yield buffer;
     }
   }
-  [Symbol.for("Deno.customInspect")]() {
+  [_computedKey12]() {
     return `SQLite3.Blob(0x${this.byteLength.toString(16)})`;
   }
 };
 
 // deno:https://jsr.io/@db/sqlite/0.13.0/src/database.ts
+var _computedKey4;
 var { sqlite3_open_v2, sqlite3_close_v2, sqlite3_changes: sqlite3_changes2, sqlite3_total_changes, sqlite3_last_insert_rowid, sqlite3_get_autocommit, sqlite3_exec, sqlite3_free, sqlite3_libversion, sqlite3_sourceid, sqlite3_complete, sqlite3_finalize: sqlite3_finalize2, sqlite3_result_blob, sqlite3_result_double, sqlite3_result_error, sqlite3_result_int64, sqlite3_result_null, sqlite3_result_text, sqlite3_value_blob, sqlite3_value_bytes, sqlite3_value_double, sqlite3_value_int64, sqlite3_value_text, sqlite3_value_type, sqlite3_create_function, sqlite3_result_int, sqlite3_aggregate_context, sqlite3_enable_load_extension, sqlite3_load_extension, sqlite3_backup_init, sqlite3_backup_step, sqlite3_backup_finish, sqlite3_errcode } = ffi_default;
 var SQLITE_VERSION = readCstr(sqlite3_libversion());
 var SQLITE_SOURCEID = readCstr(sqlite3_sourceid());
 var BIG_MAX2 = BigInt(Number.MAX_SAFE_INTEGER);
+_computedKey4 = Symbol.for("Deno.customInspect");
 var Database = class {
   #path;
   #handle;
@@ -3926,7 +3935,7 @@ var Database = class {
       unwrap(sqlite3_errcode(dest.#handle), dest.#handle);
     }
   }
-  [Symbol.for("Deno.customInspect")]() {
+  [_computedKey4]() {
     return `SQLite3.Database { path: ${this.path} }`;
   }
 };
@@ -4272,7 +4281,7 @@ var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__ge
   // file that has been converted to a CommonJS file using a Babel-
   // compatible transform (i.e. "__esModule" has not been set), then set
   // "default" to the CommonJS "module.exports" for node compatibility.
-  1 ? __defProp(target, "default", { value: mod, enumerable: true }) : target,
+  isNodeMode || !mod || !mod.__esModule ? __defProp(target, "default", { value: mod, enumerable: true }) : target,
   mod
 ));
 var require_async = __commonJS({

--- a/build/serve/creditsWorker.js
+++ b/build/serve/creditsWorker.js
@@ -33,7 +33,7 @@ var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__ge
   // file that has been converted to a CommonJS file using a Babel-
   // compatible transform (i.e. "__esModule" has not been set), then set
   // "default" to the CommonJS "module.exports" for node compatibility.
-  1 ? __defProp(target, "default", { value: mod, enumerable: true }) : target,
+  isNodeMode || !mod || !mod.__esModule ? __defProp(target, "default", { value: mod, enumerable: true }) : target,
   mod
 ));
 var require_err_helpers = __commonJS({

--- a/build/serve/ownerSizeTotalWorker.js
+++ b/build/serve/ownerSizeTotalWorker.js
@@ -33,7 +33,7 @@ var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__ge
   // file that has been converted to a CommonJS file using a Babel-
   // compatible transform (i.e. "__esModule" has not been set), then set
   // "default" to the CommonJS "module.exports" for node compatibility.
-  1 ? __defProp(target, "default", { value: mod, enumerable: true }) : target,
+  isNodeMode || !mod || !mod.__esModule ? __defProp(target, "default", { value: mod, enumerable: true }) : target,
   mod
 ));
 var require_err_helpers = __commonJS({

--- a/deno.json
+++ b/deno.json
@@ -6,7 +6,7 @@
     "compile": "deno run --allow-env --allow-ffi --allow-sys='hostname' --allow-run --allow-read --allow-write=./build,./dist scripts/compile.ts",
     "build": "deno run --node-modules-dir --allow-ffi --allow-run --allow-read --allow-env --allow-write=./build --allow-sys='cpus,homedir' scripts/dashboard-esbuild.ts && deno run --node-modules-dir --allow-ffi --allow-run --allow-read --allow-env --allow-write=./build --allow-sys='cpus,homedir,hostname' scripts/build.ts",
     "dist": "deno task lint && deno task build && deno task compile",
-    "publish": "deno run --allow-run --allow-read --allow-write=./dist,./package.json --allow-env scripts/publish.ts",
+    "publish": "deno run --allow-run --allow-read --allow-write=./build,./dist,./package.json --allow-env scripts/publish.ts",
     "sync-versions": "deno run --allow-read=. --allow-write=. --allow-run scripts/sync-versions.ts",
     "test": "deno task lint && deno task check && deno test --unstable-worker-options --allow-read=.,$HOME/.cache,$HOME/Library/Caches/deno --allow-write=.,$HOME/.cache,$HOME/Library/Caches/deno --allow-env --allow-ffi --allow-net --allow-sys --allow-run=node"
   },

--- a/scripts/binaries.test.ts
+++ b/scripts/binaries.test.ts
@@ -192,7 +192,7 @@ Deno.test('isFresh', async (t) => {
       const stamp = `${dir}/stamp.json`
       await Deno.writeTextFile(artifact, 'binary')
       await writeStamp(stamp, 'abc')
-      for (const value of ['', '0', 'false']) {
+      for (const value of ['', '0', 'false', 'False', 'FALSE']) {
         await withForceCompile(value, async () => {
           assertEquals(await isFresh(stamp, 'abc', artifact), true)
         })

--- a/scripts/binaries.test.ts
+++ b/scripts/binaries.test.ts
@@ -1,0 +1,232 @@
+import { assertEquals, assertStringIncludes } from 'jsr:@std/assert'
+import {
+  binaryPath,
+  computeFingerprint,
+  ensureArtifact,
+  isFresh,
+  normalizeMtimes,
+  stampPath,
+  writeStamp
+} from './binaries.ts'
+import { BIN_DIR, STAMP_DIR } from './paths.ts'
+import type { Target } from './targets.ts'
+
+// Ensure the temp dir exists on a fresh checkout; makeTempDir with dir does
+// not create intermediate directories. recursive: true makes this a no-op when
+// it already exists.
+await Deno.mkdir('./test/temp', { recursive: true })
+
+// test/temp is inside the project so deno task test's --allow-write=. covers it.
+const withTempDir = async (fn: (dir: string) => Promise<void>): Promise<void> => {
+  const dir = await Deno.makeTempDir({ dir: './test/temp' })
+  try {
+    await fn(dir)
+  } finally {
+    await Deno.remove(dir, { recursive: true })
+  }
+}
+
+const TARGET: Target = {
+  denoTarget: 'x86_64-unknown-linux-gnu',
+  os: 'linux',
+  cpu: 'x64',
+  binary: 'chel'
+}
+
+Deno.test('artifact paths', async (t) => {
+  await t.step('binaries are laid out as <bin dir>/<target>/<binary>', () => {
+    assertEquals(binaryPath(TARGET), `${BIN_DIR}/x86_64-unknown-linux-gnu/chel`)
+  })
+
+  await t.step('stamps live outside the binary dir so tarballs cannot pick them up', () => {
+    // The release archive is created from `BIN_DIR/<target>`; a stamp stored
+    // in there would be shipped to users.
+    const stamp = stampPath('bin', TARGET)
+    assertEquals(stamp.startsWith(`${STAMP_DIR}/`), true)
+    assertEquals(stamp.startsWith(`${BIN_DIR}/`), false)
+  })
+
+  await t.step('each artifact kind gets its own stamp per target', () => {
+    assertEquals(stampPath('bin', TARGET) === stampPath('tar', TARGET), false)
+  })
+})
+
+Deno.test('computeFingerprint', async (t) => {
+  await t.step('is stable across runs for identical contents', async () => {
+    await withTempDir(async (dir) => {
+      await Deno.writeTextFile(`${dir}/main.js`, 'console.log(1)')
+      await Deno.mkdir(`${dir}/serve`)
+      await Deno.writeTextFile(`${dir}/serve/worker.js`, 'worker')
+      assertEquals(await computeFingerprint(dir), await computeFingerprint(dir))
+    })
+  })
+
+  await t.step('ignores mtimes', async () => {
+    await withTempDir(async (dir) => {
+      await Deno.writeTextFile(`${dir}/main.js`, 'console.log(1)')
+      const before = await computeFingerprint(dir)
+      await normalizeMtimes(dir, 0)
+      assertEquals(await computeFingerprint(dir), before)
+    })
+  })
+
+  await t.step('changes when a bundled file changes', async () => {
+    await withTempDir(async (dir) => {
+      await Deno.writeTextFile(`${dir}/main.js`, 'console.log(1)')
+      const before = await computeFingerprint(dir)
+      await Deno.writeTextFile(`${dir}/main.js`, 'console.log(2)')
+      assertEquals(await computeFingerprint(dir) === before, false)
+    })
+  })
+
+  await t.step('changes when a nested file is added', async () => {
+    await withTempDir(async (dir) => {
+      await Deno.mkdir(`${dir}/dist-dashboard`)
+      await Deno.writeTextFile(`${dir}/dist-dashboard/index.html`, '<html></html>')
+      const before = await computeFingerprint(dir)
+      await Deno.writeTextFile(`${dir}/dist-dashboard/app.js`, 'app')
+      assertEquals(await computeFingerprint(dir) === before, false)
+    })
+  })
+
+  await t.step('distinguishes identical contents at different paths', async () => {
+    // Renaming a file changes what the binary embeds, so it must invalidate.
+    await withTempDir(async (dir) => {
+      await Deno.writeTextFile(`${dir}/a.js`, 'same')
+      const before = await computeFingerprint(dir)
+      await Deno.rename(`${dir}/a.js`, `${dir}/b.js`)
+      assertEquals(await computeFingerprint(dir) === before, false)
+    })
+  })
+})
+
+Deno.test('isFresh', async (t) => {
+  await t.step('true only when both the stamp and the artifact match', async () => {
+    await withTempDir(async (dir) => {
+      const artifact = `${dir}/chel`
+      const stamp = `${dir}/stamp.json`
+      await Deno.writeTextFile(artifact, 'binary')
+      await writeStamp(stamp, 'abc')
+      assertEquals(await isFresh(stamp, 'abc', artifact), true)
+    })
+  })
+
+  await t.step('false when the inputs changed', async () => {
+    await withTempDir(async (dir) => {
+      const artifact = `${dir}/chel`
+      const stamp = `${dir}/stamp.json`
+      await Deno.writeTextFile(artifact, 'binary')
+      await writeStamp(stamp, 'abc')
+      assertEquals(await isFresh(stamp, 'def', artifact), false)
+    })
+  })
+
+  await t.step('false when the artifact was deleted', async () => {
+    // A stamp on its own must never vouch for a missing artifact.
+    await withTempDir(async (dir) => {
+      const stamp = `${dir}/stamp.json`
+      await writeStamp(stamp, 'abc')
+      assertEquals(await isFresh(stamp, 'abc', `${dir}/chel`), false)
+    })
+  })
+
+  await t.step('false when there is no stamp', async () => {
+    await withTempDir(async (dir) => {
+      const artifact = `${dir}/chel`
+      await Deno.writeTextFile(artifact, 'binary')
+      assertEquals(await isFresh(`${dir}/stamp.json`, 'abc', artifact), false)
+    })
+  })
+
+  await t.step('false when the stamp is corrupt', async () => {
+    await withTempDir(async (dir) => {
+      const artifact = `${dir}/chel`
+      const stamp = `${dir}/stamp.json`
+      await Deno.writeTextFile(artifact, 'binary')
+      await Deno.writeTextFile(stamp, 'not json')
+      assertEquals(await isFresh(stamp, 'abc', artifact), false)
+    })
+  })
+
+  await t.step('writeStamp creates missing parent directories', async () => {
+    await withTempDir(async (dir) => {
+      const stamp = `${dir}/nested/deeper/stamp.json`
+      await writeStamp(stamp, 'abc')
+      assertStringIncludes(await Deno.readTextFile(stamp), 'abc')
+    })
+  })
+})
+
+Deno.test('ensureArtifact', async (t) => {
+  // ensureArtifact derives its stamp path from the target, so use a fake
+  // target whose name cannot collide with a real one, and clean up after.
+  const fakeTarget = (name: string): Target => ({
+    denoTarget: `test-${name}`,
+    os: 'linux',
+    cpu: 'x64',
+    binary: 'chel'
+  })
+
+  const cleanup = async (target: Target): Promise<void> => {
+    for (const kind of ['bin', 'tar'] as const) {
+      await Deno.remove(stampPath(kind, target)).catch(() => {})
+    }
+  }
+
+  await t.step('skips work when a previous run used the same inputs', async () => {
+    const target = fakeTarget('reuse')
+    await withTempDir(async (dir) => {
+      const artifact = `${dir}/artifact`
+      let runs = 0
+      const build = async () => {
+        runs++
+        await Deno.writeTextFile(artifact, 'built')
+      }
+      assertEquals(await ensureArtifact('tar', target, artifact, 'fp1', build), true)
+      assertEquals(await ensureArtifact('tar', target, artifact, 'fp1', build), false)
+      assertEquals(runs, 1)
+    })
+    await cleanup(target)
+  })
+
+  await t.step('redoes the work when the inputs changed', async () => {
+    const target = fakeTarget('stale')
+    await withTempDir(async (dir) => {
+      const artifact = `${dir}/artifact`
+      let runs = 0
+      const build = async () => {
+        runs++
+        await Deno.writeTextFile(artifact, `built ${runs}`)
+      }
+      await ensureArtifact('tar', target, artifact, 'fp1', build)
+      assertEquals(await ensureArtifact('tar', target, artifact, 'fp2', build), true)
+      assertEquals(runs, 2)
+      assertEquals(await Deno.readTextFile(artifact), 'built 2')
+    })
+    await cleanup(target)
+  })
+
+  await t.step('a failed run leaves the artifact marked stale', async () => {
+    // Otherwise a half-written binary from an interrupted release would be
+    // reused, and shipped.
+    const target = fakeTarget('failure')
+    await withTempDir(async (dir) => {
+      const artifact = `${dir}/artifact`
+      await Deno.writeTextFile(artifact, 'stale leftovers')
+      await writeStamp(stampPath('tar', target), 'fp1')
+
+      let failed = false
+      try {
+        await ensureArtifact('tar', target, artifact, 'fp2', () => {
+          throw new Error('compile blew up')
+        })
+      } catch {
+        failed = true
+      }
+      assertEquals(failed, true)
+      assertEquals(await isFresh(stampPath('tar', target), 'fp1', artifact), false)
+      assertEquals(await isFresh(stampPath('tar', target), 'fp2', artifact), false)
+    })
+    await cleanup(target)
+  })
+})

--- a/scripts/binaries.test.ts
+++ b/scripts/binaries.test.ts
@@ -33,6 +33,22 @@ const TARGET: Target = {
   binary: 'chel'
 }
 
+// Runs `fn` with CHEL_FORCE_COMPILE set to `value`, restoring whatever the
+// surrounding environment had (including it being unset) afterwards.
+const withForceCompile = async (value: string, fn: () => Promise<void>): Promise<void> => {
+  const previous = Deno.env.get('CHEL_FORCE_COMPILE')
+  Deno.env.set('CHEL_FORCE_COMPILE', value)
+  try {
+    await fn()
+  } finally {
+    if (previous === undefined) {
+      Deno.env.delete('CHEL_FORCE_COMPILE')
+    } else {
+      Deno.env.set('CHEL_FORCE_COMPILE', previous)
+    }
+  }
+}
+
 Deno.test('artifact paths', async (t) => {
   await t.step('binaries are laid out as <bin dir>/<target>/<binary>', () => {
     assertEquals(binaryPath(TARGET), `${BIN_DIR}/x86_64-unknown-linux-gnu/chel`)
@@ -153,6 +169,34 @@ Deno.test('isFresh', async (t) => {
       const stamp = `${dir}/nested/deeper/stamp.json`
       await writeStamp(stamp, 'abc')
       assertStringIncludes(await Deno.readTextFile(stamp), 'abc')
+    })
+  })
+
+  // CHEL_FORCE_COMPILE is the only environment input the build scripts read,
+  // and it is why they need `--allow-env`.
+  await t.step('CHEL_FORCE_COMPILE overrides an otherwise fresh cache', async () => {
+    await withTempDir(async (dir) => {
+      const artifact = `${dir}/chel`
+      const stamp = `${dir}/stamp.json`
+      await Deno.writeTextFile(artifact, 'binary')
+      await writeStamp(stamp, 'abc')
+      await withForceCompile('1', async () => {
+        assertEquals(await isFresh(stamp, 'abc', artifact), false)
+      })
+    })
+  })
+
+  await t.step('falsy CHEL_FORCE_COMPILE values leave the cache in use', async () => {
+    await withTempDir(async (dir) => {
+      const artifact = `${dir}/chel`
+      const stamp = `${dir}/stamp.json`
+      await Deno.writeTextFile(artifact, 'binary')
+      await writeStamp(stamp, 'abc')
+      for (const value of ['', '0', 'false']) {
+        await withForceCompile(value, async () => {
+          assertEquals(await isFresh(stamp, 'abc', artifact), true)
+        })
+      }
     })
   })
 })

--- a/scripts/binaries.test.ts
+++ b/scripts/binaries.test.ts
@@ -217,9 +217,20 @@ Deno.test('ensureArtifact', async (t) => {
     }
   }
 
+  // The stamps live in the real STAMP_DIR, so remove them even when an
+  // assertion throws; otherwise a failing run would leak the fake stamps
+  // into the cache directory.
+  const withCleanup = async (target: Target, fn: () => Promise<void>): Promise<void> => {
+    try {
+      await fn()
+    } finally {
+      await cleanup(target)
+    }
+  }
+
   await t.step('skips work when a previous run used the same inputs', async () => {
     const target = fakeTarget('reuse')
-    await withTempDir(async (dir) => {
+    await withCleanup(target, () => withTempDir(async (dir) => {
       const artifact = `${dir}/artifact`
       let runs = 0
       const build = async () => {
@@ -229,13 +240,12 @@ Deno.test('ensureArtifact', async (t) => {
       assertEquals(await ensureArtifact('tar', target, artifact, 'fp1', build), true)
       assertEquals(await ensureArtifact('tar', target, artifact, 'fp1', build), false)
       assertEquals(runs, 1)
-    })
-    await cleanup(target)
+    }))
   })
 
   await t.step('redoes the work when the inputs changed', async () => {
     const target = fakeTarget('stale')
-    await withTempDir(async (dir) => {
+    await withCleanup(target, () => withTempDir(async (dir) => {
       const artifact = `${dir}/artifact`
       let runs = 0
       const build = async () => {
@@ -246,15 +256,14 @@ Deno.test('ensureArtifact', async (t) => {
       assertEquals(await ensureArtifact('tar', target, artifact, 'fp2', build), true)
       assertEquals(runs, 2)
       assertEquals(await Deno.readTextFile(artifact), 'built 2')
-    })
-    await cleanup(target)
+    }))
   })
 
   await t.step('a failed run leaves the artifact marked stale', async () => {
     // Otherwise a half-written binary from an interrupted release would be
     // reused, and shipped.
     const target = fakeTarget('failure')
-    await withTempDir(async (dir) => {
+    await withCleanup(target, () => withTempDir(async (dir) => {
       const artifact = `${dir}/artifact`
       await Deno.writeTextFile(artifact, 'stale leftovers')
       await writeStamp(stampPath('tar', target), 'fp1')
@@ -270,7 +279,6 @@ Deno.test('ensureArtifact', async (t) => {
       assertEquals(failed, true)
       assertEquals(await isFresh(stampPath('tar', target), 'fp1', artifact), false)
       assertEquals(await isFresh(stampPath('tar', target), 'fp2', artifact), false)
-    })
-    await cleanup(target)
+    }))
   })
 })

--- a/scripts/binaries.ts
+++ b/scripts/binaries.ts
@@ -157,7 +157,7 @@ export async function isFresh (
   fingerprint: string,
   artifactPath: string
 ): Promise<boolean> {
-  const force = Deno.env.get('CHEL_FORCE_COMPILE')
+  const force = Deno.env.get('CHEL_FORCE_COMPILE')?.toLowerCase()
   if (force && force !== '0' && force !== 'false') return false
   if (!await exists(artifactPath)) return false
   try {

--- a/scripts/binaries.ts
+++ b/scripts/binaries.ts
@@ -1,0 +1,222 @@
+// Content-addressed cache for the compiled native binaries.
+//
+// A release needs the same five native binaries twice: once inside the
+// GitHub release tarballs (scripts/compile.ts) and once inside the npm
+// platform sub-packages (scripts/publish.ts). Compiling them separately meant
+// running `deno compile` ten times per release, which is both slow and
+// pointless: the inputs are identical, so the outputs are too.
+//
+// Instead both consumers call `ensureBinaries()`, which compiles into a single
+// shared location (`dist/bin/<target>/<binary>`) and skips any target whose
+// binary was already built from the exact same inputs. Freshness is decided by
+// content, not timestamps: a fingerprint of every file the binary embeds (the
+// whole `build/` bundle), plus the Deno version and the compile flags, is
+// recorded next to the artifact and compared on the next run.
+//
+// Consequences worth knowing:
+//   - `deno task dist` twice in a row does no compilation the second time
+//   - `deno task dist` followed by `npm publish` compiles once in total, and
+//     the published binary is byte-identical to the one in the tarball
+//   - touching anything under `build/`, upgrading Deno, or changing the
+//     compile flags invalidates the cache automatically
+//   - `dist/` is gitignored, so the cache is per-checkout and never shipped
+//
+// Set CHEL_FORCE_COMPILE=1 to ignore the cache and recompile everything.
+
+import { encodeHex } from 'jsr:@std/encoding/hex'
+import { dirname } from 'jsr:@std/path/'
+import { BIN_DIR, BUILD_DIR, STAMP_DIR } from './paths.ts'
+import { COMPILE_FLAGS, TARGETS, compileBinary, type Target } from './targets.ts'
+
+// Kinds of cached artifact, each with its own stamp file per target.
+export type ArtifactKind = 'bin' | 'tar'
+
+export function binaryDir (target: Target): string {
+  return `${BIN_DIR}/${target.denoTarget}`
+}
+
+export function binaryPath (target: Target): string {
+  return `${binaryDir(target)}/${target.binary}`
+}
+
+export function stampPath (kind: ArtifactKind, target: Target): string {
+  return `${STAMP_DIR}/${kind}-${target.denoTarget}.json`
+}
+
+function isNotFound (e: unknown): boolean {
+  return e instanceof Error && e.name === 'NotFound'
+}
+
+async function removeIfPresent (path: string): Promise<void> {
+  try {
+    await Deno.remove(path)
+  } catch (e) {
+    if (!isNotFound(e)) throw e
+  }
+}
+
+async function exists (path: string): Promise<boolean> {
+  try {
+    await Deno.stat(path)
+    return true
+  } catch (e) {
+    if (isNotFound(e)) return false
+    throw e
+  }
+}
+
+// `deno compile` embeds each source file's mtime into the resulting binary,
+// which makes consecutive builds produce different output even when the file
+// contents are identical. Setting every mtime below `build/` to a fixed value
+// (the UNIX epoch) before compiling restores determinism on a given host.
+export async function normalizeMtimes (dir: string, time: number): Promise<void> {
+  const entries: Deno.DirEntry[] = []
+  try {
+    for await (const entry of Deno.readDir(dir)) entries.push(entry)
+  } catch (e) {
+    if (isNotFound(e)) return
+    throw e
+  }
+  for (const entry of entries) {
+    // Skip symlinks: Deno.utime follows symlinks (there is no lutime
+    // equivalent), so calling it on a symlink would mutate the target's
+    // mtime rather than the link's. entry.isDirectory is lstat-based and
+    // therefore already false for symlinks, so this guard (not the
+    // recursion below) is what prevents the utime side-effect.
+    if (entry.isSymlink) continue
+    const path = `${dir}/${entry.name}`
+    try {
+      await Deno.utime(path, time, time)
+    } catch (e) {
+      if (!isNotFound(e)) throw e
+    }
+    if (entry.isDirectory) {
+      await normalizeMtimes(path, time)
+    }
+  }
+}
+
+async function sha256 (bytes: Uint8Array<ArrayBuffer>): Promise<string> {
+  return encodeHex(await crypto.subtle.digest('SHA-256', bytes))
+}
+
+// `<relative path>\t<sha256 of contents>` for every regular file under `dir`,
+// recursively. Symlinks are skipped for the same reason as in normalizeMtimes:
+// what matters is the bytes `deno compile` embeds, and a link's target is
+// hashed anyway when it lives inside the tree.
+async function fileDigests (dir: string, prefix = ''): Promise<string[]> {
+  const digests: string[] = []
+  for await (const entry of Deno.readDir(dir)) {
+    if (entry.isSymlink) continue
+    const rel = prefix ? `${prefix}/${entry.name}` : entry.name
+    const path = `${dir}/${entry.name}`
+    if (entry.isDirectory) {
+      digests.push(...await fileDigests(path, rel))
+    } else {
+      digests.push(`${rel}\t${await sha256(await Deno.readFile(path))}`)
+    }
+  }
+  return digests
+}
+
+// Identifies the inputs of a `deno compile` run: the bundle contents, the
+// toolchain, and the flags. Two runs sharing a fingerprint produce the same
+// binaries, so a cached artifact carrying it can be reused as-is.
+export async function computeFingerprint (dir: string = BUILD_DIR): Promise<string> {
+  const payload = [
+    `deno:${Deno.version.deno}`,
+    `flags:${COMPILE_FLAGS}`,
+    ...(await fileDigests(dir)).sort()
+  ].join('\n')
+  return await sha256(new TextEncoder().encode(payload))
+}
+
+// Memoized so the (multi-megabyte) bundle is hashed once per process even
+// though both the binary and the tarball steps ask for it.
+let cachedFingerprint: string | undefined
+export async function bundleFingerprint (): Promise<string> {
+  if (cachedFingerprint === undefined) {
+    cachedFingerprint = await computeFingerprint()
+  }
+  return cachedFingerprint
+}
+
+// Records the inputs an artifact was produced from. Creates the containing
+// directory, so callers never have to.
+export async function writeStamp (path: string, fingerprint: string): Promise<void> {
+  await Deno.mkdir(dirname(path), { recursive: true })
+  await Deno.writeTextFile(path, JSON.stringify({ fingerprint }, null, 2) + '\n')
+}
+
+// True iff `artifactPath` exists and was produced from `fingerprint`. Both
+// conditions matter: the stamp alone would happily vouch for an artifact that
+// was deleted, and the artifact alone says nothing about what produced it.
+// Anything unreadable or unparseable counts as stale, never as fresh.
+export async function isFresh (
+  stampFile: string,
+  fingerprint: string,
+  artifactPath: string
+): Promise<boolean> {
+  const force = Deno.env.get('CHEL_FORCE_COMPILE')
+  if (force && force !== '0' && force !== 'false') return false
+  if (!await exists(artifactPath)) return false
+  try {
+    const stamp = JSON.parse(await Deno.readTextFile(stampFile))
+    return stamp?.fingerprint === fingerprint
+  } catch {
+    return false
+  }
+}
+
+// Runs `fn` to (re)create `artifactPath` unless a previous run already
+// produced it from the same inputs. The stamp is deleted before `fn` runs and
+// only written after it returns, so an interrupted or failed run leaves the
+// artifact marked stale rather than falsely fresh.
+export async function ensureArtifact (
+  kind: ArtifactKind,
+  target: Target,
+  artifactPath: string,
+  fingerprint: string,
+  fn: () => Promise<void>
+): Promise<boolean> {
+  const stampFile = stampPath(kind, target)
+  if (await isFresh(stampFile, fingerprint, artifactPath)) {
+    console.log(`Reusing ${artifactPath} (unchanged inputs)`)
+    return false
+  }
+  await removeIfPresent(stampFile)
+  await fn()
+  await writeStamp(stampFile, fingerprint)
+  return true
+}
+
+// Makes sure every target in `targets` has an up-to-date native binary under
+// `dist/bin/`, compiling only the ones that are missing or stale. Returns the
+// number of binaries actually compiled.
+export async function ensureBinaries (targets: readonly Target[] = TARGETS): Promise<number> {
+  const fingerprint = await bundleFingerprint()
+  const stale: Target[] = []
+  for (const target of targets) {
+    if (await isFresh(stampPath('bin', target), fingerprint, binaryPath(target))) {
+      console.log(`Reusing ${binaryPath(target)} (unchanged inputs)`)
+    } else {
+      stale.push(target)
+    }
+  }
+  if (stale.length === 0) return 0
+
+  // Only needed when something is actually compiled, and deliberately done
+  // once for all of them: the binaries must be reproducible across targets and
+  // across the tarball/sub-package consumers alike.
+  await normalizeMtimes(BUILD_DIR, 0)
+  for (const target of stale) {
+    console.log(`\n--- Compiling ${target.denoTarget} ---`)
+    await Deno.mkdir(binaryDir(target), { recursive: true })
+    // Mark stale up front, stamp only on success: an interrupted compile must
+    // never leave a half-written binary looking current.
+    await removeIfPresent(stampPath('bin', target))
+    await compileBinary(binaryPath(target), target)
+    await writeStamp(stampPath('bin', target), fingerprint)
+  }
+  return stale.length
+}

--- a/scripts/binaries.ts
+++ b/scripts/binaries.ts
@@ -168,10 +168,22 @@ export async function isFresh (
   }
 }
 
+// The stamp is deleted before `fn` runs and only written after it returns, so
+// an interrupted or failed run leaves the artifact marked stale rather than
+// falsely fresh. Shared by every cached artifact, so that invariant lives in
+// one place.
+async function rebuildWithStamp (
+  stampFile: string,
+  fingerprint: string,
+  fn: () => Promise<void>
+): Promise<void> {
+  await removeIfPresent(stampFile)
+  await fn()
+  await writeStamp(stampFile, fingerprint)
+}
+
 // Runs `fn` to (re)create `artifactPath` unless a previous run already
-// produced it from the same inputs. The stamp is deleted before `fn` runs and
-// only written after it returns, so an interrupted or failed run leaves the
-// artifact marked stale rather than falsely fresh.
+// produced it from the same inputs.
 export async function ensureArtifact (
   kind: ArtifactKind,
   target: Target,
@@ -184,9 +196,7 @@ export async function ensureArtifact (
     console.log(`Reusing ${artifactPath} (unchanged inputs)`)
     return false
   }
-  await removeIfPresent(stampFile)
-  await fn()
-  await writeStamp(stampFile, fingerprint)
+  await rebuildWithStamp(stampFile, fingerprint, fn)
   return true
 }
 
@@ -212,11 +222,9 @@ export async function ensureBinaries (targets: readonly Target[] = TARGETS): Pro
   for (const target of stale) {
     console.log(`\n--- Compiling ${target.denoTarget} ---`)
     await Deno.mkdir(binaryDir(target), { recursive: true })
-    // Mark stale up front, stamp only on success: an interrupted compile must
-    // never leave a half-written binary looking current.
-    await removeIfPresent(stampPath('bin', target))
-    await compileBinary(binaryPath(target), target)
-    await writeStamp(stampPath('bin', target), fingerprint)
+    await rebuildWithStamp(stampPath('bin', target), fingerprint, () =>
+      compileBinary(binaryPath(target), target)
+    )
   }
   return stale.length
 }

--- a/scripts/binaries.ts
+++ b/scripts/binaries.ts
@@ -123,11 +123,13 @@ async function fileDigests (dir: string, prefix = ''): Promise<string[]> {
 // toolchain, and the flags. Two runs sharing a fingerprint produce the same
 // binaries, so a cached artifact carrying it can be reused as-is.
 export async function computeFingerprint (dir: string = BUILD_DIR): Promise<string> {
+  // Using NUL because `fileDigests` could contain
+  // most other characters
   const payload = [
     `deno:${Deno.version.deno}`,
     `flags:${COMPILE_FLAGS}`,
     ...(await fileDigests(dir)).sort()
-  ].join('\n')
+  ].join('\0')
   return await sha256(new TextEncoder().encode(payload))
 }
 

--- a/scripts/compile.ts
+++ b/scripts/compile.ts
@@ -48,8 +48,8 @@ const { default: { version } } = await import('../package.json', { with: { type:
 const TAR_FORMAT_VERSION = '1'
 
 // Cache key for a tarball: the inputs it holds, plus how it was packed.
-export function tarFingerprint (bundleFingerprint: string): string {
-  return `${bundleFingerprint}:tar${TAR_FORMAT_VERSION}`
+export function tarFingerprint (bundleFp: string): string {
+  return `${bundleFp}:tar${TAR_FORMAT_VERSION}`
 }
 
 // Detect whether the system `tar` is GNU tar. bsdtar (macOS default) rejects

--- a/scripts/compile.ts
+++ b/scripts/compile.ts
@@ -1,43 +1,32 @@
 #!/usr/bin/env -S deno run --allow-run --allow-read=. --allow-write=./build,./dist
 
-import { shell, $ } from '~/utils.ts'
+// When: `deno task compile`, and as the last step of `deno task dist`.
+//
+// Produces the GitHub release tarballs: one reproducible
+// `dist/chel-v<version>-<target>.tar.gz` per supported platform, followed by
+// their SHA-256 checksums.
+//
+// The native binaries themselves are not compiled here; they are requested
+// from the shared cache in `./binaries.ts`, which is also what the npm
+// publish step uses. Running this script before `npm publish` therefore makes
+// the release compile each binary once instead of once per consumer, and
+// guarantees the bytes shipped to npm are the bytes shipped on GitHub.
+// Re-running it is close to free: unchanged targets are neither recompiled
+// nor re-archived.
+
 import { encodeHex } from 'jsr:@std/encoding/hex'
-import { TARGETS, compileBinary } from './targets.ts'
+import { TARGETS } from './targets.ts'
+import { BIN_DIR, DIST_DIR } from './paths.ts'
+import {
+  bundleFingerprint,
+  ensureArtifact,
+  ensureBinaries,
+  normalizeMtimes
+} from './binaries.ts'
 
 // Static import for TS JSON-import-attribute type inference. The path also
 // lives in `rootPackagePath()` from `./sync-versions.ts`; keep both in sync.
 const { default: { version } } = await import('../package.json', { with: { type: 'json' } })
-
-// `deno compile` embeds each source file's mtime into the resulting binary,
-// which makes consecutive builds produce different output even when the file
-// contents are identical. Setting every mtime below `build/` to a fixed value
-// (the UNIX epoch) before compiling restores determinism on a given host.
-async function normalizeMtimes (dir: string, time: number): Promise<void> {
-  const entries: Deno.DirEntry[] = []
-  try {
-    for await (const entry of Deno.readDir(dir)) entries.push(entry)
-  } catch (e) {
-    if (e instanceof Error && e.name === 'NotFound') return
-    throw e
-  }
-  for (const entry of entries) {
-    // Skip symlinks: Deno.utime follows symlinks (there is no lutime
-    // equivalent), so calling it on a symlink would mutate the target's
-    // mtime rather than the link's. entry.isDirectory is lstat-based and
-    // therefore already false for symlinks, so this guard (not the
-    // recursion below) is what prevents the utime side-effect.
-    if (entry.isSymlink) continue
-    const path = `${dir}/${entry.name}`
-    try {
-      await Deno.utime(path, time, time)
-    } catch (e) {
-      if (!(e instanceof Error && e.name === 'NotFound')) throw e
-    }
-    if (entry.isDirectory) {
-      await normalizeMtimes(path, time)
-    }
-  }
-}
 
 // Build a reproducible .tar.gz in a single tar invocation. Running tar and gzip
 // in one process group (rather than a shell pipeline `tar | gzip > out`) yields
@@ -164,30 +153,24 @@ async function printSha256Sums (dir: string, prefix: string): Promise<void> {
 }
 
 export async function compile (): Promise<void> {
-  await normalizeMtimes('./build', 0)
+  await ensureBinaries()
+  const fingerprint = await bundleFingerprint()
   for (const target of TARGETS) {
-    const { denoTarget, binary } = target
-    const dir = `./dist/tmp/${denoTarget}`
-    // note: could also use https://examples.deno.land/temporary-files
-    await $(`mkdir -vp ${dir}`)
-    await compileBinary(`${dir}/${binary}`, target)
-    await reproducibleTarGz('./dist/tmp', `./dist/chel-v${version}-${denoTarget}.tar.gz`, denoTarget)
+    const { denoTarget } = target
+    const archivePath = `${DIST_DIR}/chel-v${version}-${denoTarget}.tar.gz`
+    // The archive holds `<target>/<binary>`, so it can be created straight out
+    // of the shared binary cache: BIN_DIR is already laid out that way.
+    await ensureArtifact('tar', target, archivePath, fingerprint, () =>
+      reproducibleTarGz(BIN_DIR, archivePath, denoTarget)
+    )
   }
-  await printSha256Sums('dist', `chel-v${version}-`)
+  await printSha256Sums(DIST_DIR, `chel-v${version}-`)
   // TODO: sign the sha256sum! pipe this to gpg and include a link to your GPG key in the release notes!
 }
 
-let exitCode = 0
 try {
   await compile()
 } catch (e) {
   console.error('caught:', e)
-  exitCode = 1
-} finally {
-  try {
-    await shell('rm -rf ./dist/tmp')
-  } catch (e) {
-    console.error('cleanup failed:', e)
-  }
+  Deno.exit(1)
 }
-if (exitCode !== 0) Deno.exit(exitCode)

--- a/scripts/compile.ts
+++ b/scripts/compile.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S deno run --allow-run --allow-read=. --allow-write=./build,./dist
+#!/usr/bin/env -S deno run --allow-env --allow-run --allow-read=. --allow-write=./build,./dist
 
 // When: `deno task compile`, and as the last step of `deno task dist`.
 //
@@ -38,6 +38,19 @@ const { default: { version } } = await import('../package.json', { with: { type:
 // on a given host. The owner/group/format/mtime and entry-order guarantees are
 // achieved with different flag sets on GNU tar vs bsdtar (the macOS default);
 // see buildTarArgs below.
+
+// The archive bytes depend on the tar invocation below as much as on the
+// binaries going into it, but the bundle fingerprint from ./binaries.ts only
+// covers the latter. Bump this whenever anything that shapes the archive
+// changes (the tar flags, the compression level, the entry order, the bsdtar
+// fallback), so cached tarballs from earlier runs are rebuilt instead of
+// silently reused.
+const TAR_FORMAT_VERSION = '1'
+
+// Cache key for a tarball: the inputs it holds, plus how it was packed.
+export function tarFingerprint (bundleFingerprint: string): string {
+  return `${bundleFingerprint}:tar${TAR_FORMAT_VERSION}`
+}
 
 // Detect whether the system `tar` is GNU tar. bsdtar (macOS default) rejects
 // GNU-only options such as `--sort=name`, `--owner`, `--group` and `--mtime`.
@@ -154,7 +167,7 @@ async function printSha256Sums (dir: string, prefix: string): Promise<void> {
 
 export async function compile (): Promise<void> {
   await ensureBinaries()
-  const fingerprint = await bundleFingerprint()
+  const fingerprint = tarFingerprint(await bundleFingerprint())
   for (const target of TARGETS) {
     const { denoTarget } = target
     const archivePath = `${DIST_DIR}/chel-v${version}-${denoTarget}.tar.gz`
@@ -168,9 +181,14 @@ export async function compile (): Promise<void> {
   // TODO: sign the sha256sum! pipe this to gpg and include a link to your GPG key in the release notes!
 }
 
-try {
-  await compile()
-} catch (e) {
-  console.error('caught:', e)
-  Deno.exit(1)
+// Guarded like the CLI body in ./sync-versions.ts, so this module can be
+// imported (by tests, or by a future release script) without kicking off a
+// multi-target compile as a side effect of the import.
+if (import.meta.main) {
+  try {
+    await compile()
+  } catch (e) {
+    console.error('caught:', e)
+    Deno.exit(1)
+  }
 }

--- a/scripts/dist.ts
+++ b/scripts/dist.ts
@@ -1,3 +1,8 @@
-// TODO: 1. run `deno lint` - stop if there's an error
-//       2. run build and then compile
-//       3. update hashes in README.md
+// Placeholder for a future one-shot distribution entry point.
+//
+// Steps 1 and 2 of the original plan (lint, then build and compile) are now
+// covered by the `dist` task in deno.json, and the compile step prints the
+// SHA256 checksums of the release tarballs.
+//
+// TODO: sign the checksums and attach them to the GitHub release.
+export {}

--- a/scripts/paths.ts
+++ b/scripts/paths.ts
@@ -10,3 +10,16 @@ export const BUNDLE_PATH = `${BUILD_DIR}/main.js`
 export const SERVE_DIR = `${BUILD_DIR}/serve`
 export const VERSION_STAMP_PATH = `${BUILD_DIR}/version.json`
 export const DASHBOARD_DIR = `${BUILD_DIR}/dist-dashboard`
+
+// Release artifacts. Everything below lives under the gitignored `dist/`, and
+// is shared by the two consumers of the native binaries: the release tarballs
+// (scripts/compile.ts) and the npm platform sub-packages (scripts/publish.ts).
+//
+// `BIN_DIR` is the single place a compiled binary is written to. Both
+// consumers read from it instead of compiling their own copy, so a release
+// runs `deno compile` once per target rather than twice.
+export const DIST_DIR = 'dist'
+export const BIN_DIR = `${DIST_DIR}/bin`
+// Freshness records for the cached artifacts. Deliberately outside BIN_DIR so
+// that archiving `BIN_DIR/<target>` cannot sweep them into a release tarball.
+export const STAMP_DIR = `${DIST_DIR}/.stamps`

--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -39,6 +39,7 @@
 import { shell, $ } from '~/utils.ts'
 import {
   TARGETS,
+  EXEC_MODE,
   subPackageName,
   subPackageDir,
   subPackageManifest
@@ -141,7 +142,7 @@ async function createSubPackages (): Promise<void> {
     // present in the published tarball (npm never fixes it up, see
     // BINARY_FIELD), so make it a guarantee rather than an assumption.
     if (target.os !== 'win32') {
-      await Deno.chmod(binaryDest, 0o755)
+      await Deno.chmod(binaryDest, EXEC_MODE)
     }
 
     const subPkg = subPackageManifest(target, rootPkg)

--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S deno run --allow-run --allow-read --allow-write=./dist,./package.json --allow-env
+#!/usr/bin/env -S deno run --allow-run --allow-read --allow-write=./build,./dist,./package.json --allow-env
 
 // When: Automatically invoked by `npm publish` via the "prepublishOnly"
 //       script in package.json. Runs just before the main package is
@@ -12,14 +12,23 @@
 // which calls `deno task publish`. It:
 //   0. Verifies the committed bundle is fresh and the tree is clean for the
 //      bundle paths (see assertFreshBundle); refuses to publish otherwise
-//   1. For each OS/CPU target, compiles a native binary from the committed
-//      `build/` bundle and writes it under `dist/cli-<cpu>-<os>/` together
-//      with a minimal `package.json`
+//   1. For each OS/CPU target, obtains a native binary built from the
+//      committed `build/` bundle and assembles `dist/cli-<cpu>-<os>/` around
+//      it, together with a minimal `package.json`
 //   2. Publishes each platform sub-package to npm
 //
 // The JS bundle itself is NOT rebuilt here: it is built and committed by the
 // npm `version` lifecycle hook (see package.json), so what gets published is
 // exactly what the version commit and tag contain.
+//
+// The binaries are likewise not necessarily compiled here: they come from the
+// shared cache in `./binaries.ts`. A release that already produced the GitHub
+// tarballs (`deno task dist`) therefore reuses those exact binaries instead of
+// spending minutes recompiling identical ones, which also guarantees npm and
+// GitHub ship the same bytes. If no cached binary matches the committed
+// bundle, it is compiled on demand, so publishing on its own still works.
+// Compiling writes nothing to `build/` beyond pinning mtimes for
+// reproducibility, which is why this script may write there.
 //
 // When this script finishes, the outer `npm publish` publishes the main package,
 // whose `optionalDependencies` now reference the freshly published sub-packages.
@@ -30,11 +39,11 @@
 import { shell, $ } from '~/utils.ts'
 import {
   TARGETS,
-  compileBinary,
   subPackageName,
   subPackageDir,
   subPackageManifest
 } from './targets.ts'
+import { binaryPath, ensureBinaries } from './binaries.ts'
 import { reconcileOptionalDeps, rootPackagePath } from './sync-versions.ts'
 import { BUILD_DIR, VERSION_STAMP_PATH, SERVE_DIR, DASHBOARD_DIR } from './paths.ts'
 
@@ -114,17 +123,26 @@ async function assertFreshBundle (): Promise<void> {
 }
 
 async function createSubPackages (): Promise<void> {
-  console.log('=== Step 1: Compiling binaries & creating sub-packages ===')
-  await $('rm -rf ./dist && mkdir -p ./dist')
+  console.log('=== Step 1: Obtaining binaries & creating sub-packages ===')
+  await ensureBinaries()
 
   for (const target of TARGETS) {
     const subPkgName = subPackageName(target)
     const subDir = subPackageDir(target)
 
     console.log(`\n--- ${subPkgName} (${target.denoTarget}) ---`)
-    await $(`mkdir -p ${subDir}`)
+    // Only the sub-package directory is wiped, never the whole of `dist/`:
+    // that is where the shared binary cache and the release tarballs live.
+    await $(`rm -rf ${subDir} && mkdir -p ${subDir}`)
 
-    await compileBinary(`${subDir}/${target.binary}`, target)
+    const binaryDest = `${subDir}/${target.binary}`
+    await Deno.copyFile(binaryPath(target), binaryDest)
+    // Deno.copyFile preserves the mode, but the executable bit has to be
+    // present in the published tarball (npm never fixes it up, see
+    // BINARY_FIELD), so make it a guarantee rather than an assumption.
+    if (target.os !== 'win32') {
+      await Deno.chmod(binaryDest, 0o755)
+    }
 
     const subPkg = subPackageManifest(target, rootPkg)
     await Deno.writeTextFile(

--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -28,7 +28,13 @@
 // matching the previous `bin/` behavior.
 
 import { shell, $ } from '~/utils.ts'
-import { TARGETS, compileBinary, subPackageName, subPackageDir } from './targets.ts'
+import {
+  TARGETS,
+  compileBinary,
+  subPackageName,
+  subPackageDir,
+  subPackageManifest
+} from './targets.ts'
 import { reconcileOptionalDeps, rootPackagePath } from './sync-versions.ts'
 import { BUILD_DIR, VERSION_STAMP_PATH, SERVE_DIR, DASHBOARD_DIR } from './paths.ts'
 
@@ -120,20 +126,7 @@ async function createSubPackages (): Promise<void> {
 
     await compileBinary(`${subDir}/${target.binary}`, target)
 
-    const subPkg = {
-      name: subPkgName,
-      version: rootPkg.version,
-      description: `${rootPkg.description} (${target.os}/${target.cpu})`,
-      repository: rootPkg.repository,
-      author: rootPkg.author,
-      license: rootPkg.license,
-      os: [target.os],
-      cpu: [target.cpu],
-      files: [target.binary, 'LICENSE'],
-      bin: {
-        chel: target.binary
-      }
-    }
+    const subPkg = subPackageManifest(target, rootPkg)
     await Deno.writeTextFile(
       `${subDir}/package.json`,
       JSON.stringify(subPkg, null, 2) + '\n'

--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -186,15 +186,22 @@ async function publishSubPackages (): Promise<void> {
   }
 }
 
-try {
-  await assertFreshBundle()
-  await createSubPackages()
-  await publishSubPackages()
-  const pkgPath = rootPackagePath()
-  const synced = await reconcileOptionalDeps(pkgPath, rootPkg.version, TARGETS)
-  if (synced) console.log(`\nSynced optionalDependencies -> ${rootPkg.version}`)
-  console.log('\n=== Sub-packages published. Publishing main package... ===')
-} catch (e) {
-  console.error('caught:', e)
-  Deno.exit(1)
+// Guarded like ./compile.ts and ./sync-versions.ts, so importing this module
+// can never publish to npm as a side effect. publish.ts is the one place
+// where that would be destructive: publishing is close to irreversible
+// (sub-packages can only be unpublished within 72h), so it must only happen
+// when the script is actually run, never when it is merely imported.
+if (import.meta.main) {
+  try {
+    await assertFreshBundle()
+    await createSubPackages()
+    await publishSubPackages()
+    const pkgPath = rootPackagePath()
+    const synced = await reconcileOptionalDeps(pkgPath, rootPkg.version, TARGETS)
+    if (synced) console.log(`\nSynced optionalDependencies -> ${rootPkg.version}`)
+    console.log('\n=== Sub-packages published. Publishing main package... ===')
+  } catch (e) {
+    console.error('caught:', e)
+    Deno.exit(1)
+  }
 }

--- a/scripts/sync-versions.ts
+++ b/scripts/sync-versions.ts
@@ -22,8 +22,8 @@ import { shell } from '~/utils.ts'
 import { TARGETS, subPackageName, isCliSubPackage, type Target } from './targets.ts'
 
 // Absolute path to the root package.json. Used by runtime lookups in this file
-// (the `import.meta.main` CLI block) and in `publish.ts` (the `try` block) via
-// `Deno.readTextFile`. The literal `'../package.json'` also appears in static
+// (the `import.meta.main` CLI block) and in `publish.ts` (its own
+// `import.meta.main` block) via `Deno.readTextFile`. The literal `'../package.json'` also appears in static
 // `import(... { with: { type: 'json' } })` calls in `publish.ts`, `compile.ts`,
 // and `build.ts`; those cannot use this function because TS needs a static
 // string for JSON-import-attribute type inference. Keep all references in sync

--- a/scripts/targets.test.ts
+++ b/scripts/targets.test.ts
@@ -1,11 +1,21 @@
 import { assertEquals } from 'jsr:@std/assert'
 import {
   TARGETS,
+  BINARY_FIELD,
   subPackageName,
   subPackageDir,
+  subPackageManifest,
   isCliSubPackage,
   type Target
 } from './targets.ts'
+
+const ROOT_PKG = {
+  version: '9.9.9',
+  description: 'Chelonia Command-line Interface',
+  repository: { type: 'git', url: 'git+https://example.com/chel.git' },
+  author: 'Someone <someone@example.com>',
+  license: 'AGPL-3.0'
+}
 
 Deno.test('subPackageName', async (t) => {
   await t.step('formats as <prefix><cpu>-<os>', () => {
@@ -60,6 +70,79 @@ Deno.test('bin/chel.js naming convention matches subPackageName', () => {
     const runtime = `@chelonia/cli-${target.cpu}-${target.os}`
     assertEquals(subPackageName(target), runtime)
   }
+})
+
+Deno.test('bin/chel.js reads the binary field the sub-packages publish', () => {
+  // The shim cannot import this module (it is CommonJS run by npm at install
+  // time), so the field name is duplicated there. Pin the duplication: a
+  // mismatch would make every install look for the wrong path.
+  const src = Deno.readTextFileSync(new URL('../bin/chel.js', import.meta.url))
+  assertEquals(
+    src.includes(`subPkg.${BINARY_FIELD}`),
+    true,
+    `bin/chel.js must read subPkg.${BINARY_FIELD}`
+  )
+
+  // The filenames the shim falls back to must match what the compiler actually
+  // produces for each platform.
+  for (const target of TARGETS) {
+    assertEquals(
+      src.includes(`'${target.binary}'`),
+      true,
+      `bin/chel.js fallback is missing the '${target.binary}' filename`
+    )
+  }
+})
+
+Deno.test('subPackageManifest', async (t) => {
+  await t.step('never declares a bin field', () => {
+    // A `bin` entry named `chel` in a sub-package competes with the root
+    // package for the same `node_modules/.bin/chel` link and clobbers the
+    // launcher, which is what broke installs under npm 10.
+    for (const target of TARGETS) {
+      const manifest = subPackageManifest(target, ROOT_PKG)
+      assertEquals('bin' in manifest, false, `${subPackageName(target)} must not declare bin`)
+      // npm expands `directories.bin` into bin entries, so it is banned too.
+      assertEquals('directories' in manifest, false)
+    }
+  })
+
+  await t.step('advertises the binary under the custom field', () => {
+    for (const target of TARGETS) {
+      const manifest = subPackageManifest(target, ROOT_PKG)
+      assertEquals(manifest[BINARY_FIELD], target.binary)
+    }
+  })
+
+  await t.step('ships the binary and the license', () => {
+    for (const target of TARGETS) {
+      const manifest = subPackageManifest(target, ROOT_PKG)
+      assertEquals(manifest.files, [target.binary, 'LICENSE'])
+    }
+  })
+
+  await t.step('asks Yarn PnP to keep the package unzipped', () => {
+    // The launcher spawns a real file; a zipped package would have none.
+    for (const target of TARGETS) {
+      assertEquals(subPackageManifest(target, ROOT_PKG).preferUnplugged, true)
+    }
+  })
+
+  await t.step('inherits root metadata and restricts the platform', () => {
+    const target = TARGETS[0]
+    const manifest = subPackageManifest(target, ROOT_PKG)
+    assertEquals(manifest.name, subPackageName(target))
+    assertEquals(manifest.version, ROOT_PKG.version)
+    assertEquals(manifest.os, [target.os])
+    assertEquals(manifest.cpu, [target.cpu])
+    assertEquals(manifest.license, ROOT_PKG.license)
+    assertEquals(manifest.author, ROOT_PKG.author)
+    assertEquals(manifest.repository, ROOT_PKG.repository)
+    assertEquals(
+      manifest.description,
+      `${ROOT_PKG.description} (${target.os}/${target.cpu})`
+    )
+  })
 })
 
 Deno.test('subPackageDir', async (t) => {

--- a/scripts/targets.ts
+++ b/scripts/targets.ts
@@ -1,8 +1,8 @@
 // Shared compilation target metadata and `deno compile` invocation.
 //
-// Consumed by both `scripts/compile.ts` (local native builds) and
-// `scripts/publish.ts` (release sub-packages) so that the set of targets,
-// permission flags, and --include paths cannot drift between the two.
+// Consumed through `scripts/binaries.ts` by both `scripts/compile.ts` (release
+// tarballs) and `scripts/publish.ts` (npm sub-packages), so that the set of
+// targets, permission flags, and --include paths cannot drift between the two.
 
 import { shell } from '~/utils.ts'
 import { BUNDLE_PATH, SERVE_DIR, DASHBOARD_DIR } from './paths.ts'
@@ -101,13 +101,17 @@ export function isCliSubPackage (name: string): boolean {
 }
 
 // The full `deno compile` permission flag set + static include/exclude paths.
-// Kept here so the two call sites (compile.ts, publish.ts) cannot diverge.
+// Kept here so the two call sites (the release tarballs and the npm
+// sub-packages, both of which go through scripts/binaries.ts) cannot diverge.
+//
+// Exported because the binary cache folds it into its fingerprint: changing a
+// flag changes the resulting binaries, so it must invalidate cached ones.
 //
 // `--allow-read` (unrestricted) instead of `--allow-read=.` because Deno may
 // need to load from its cache at runtime, and the cache path isn't known at
 // compile time.
 // TODO: fix upstream in Deno, or drop permissions programmatically at runtime.
-const COMPILE_FLAGS =
+export const COMPILE_FLAGS =
   '--allow-env --allow-ffi --allow-sys=hostname --allow-read --allow-write=./ --allow-net ' +
   `--exclude node_modules --include ./${SERVE_DIR} --include ./${DASHBOARD_DIR}`
 

--- a/scripts/targets.ts
+++ b/scripts/targets.ts
@@ -45,6 +45,53 @@ export function subPackageName (t: Target): string {
   return `${CLI_SUBPACKAGE_PREFIX}${t.cpu}-${t.os}`
 }
 
+// Field under which a sub-package advertises its binary's filename.
+//
+// Sub-packages must NOT use `bin` for this. npm links the `bin` entries of
+// every package in the tree into the same `node_modules/.bin` directory, so a
+// sub-package claiming the name `chel` competes with the root package's
+// launcher for that link: whichever is linked last wins, and on npm 10 that is
+// frequently the sub-package, leaving `.bin/chel` pointing at a native binary
+// whose sibling packages were never checked (and, on install failures, a
+// dangling link). Publishing the filename under a field npm ignores keeps
+// `chel` owned solely by the root package while still letting bin/chel.js find
+// the executable. `directories.bin` is likewise unusable: npm expands it into
+// `bin` entries.
+export const BINARY_FIELD = 'chelBinary'
+
+// Subset of the root package.json that sub-packages inherit metadata from.
+export interface RootPackageMeta {
+  version: string
+  description: string
+  repository: unknown
+  author: string
+  license: string
+}
+
+// The complete package.json contents for `target`'s sub-package. Shared with
+// the tests so the "no bin field" invariant is pinned rather than assumed.
+export function subPackageManifest (
+  target: Target,
+  rootPkg: RootPackageMeta
+): Record<string, unknown> {
+  return {
+    name: subPackageName(target),
+    version: rootPkg.version,
+    description: `${rootPkg.description} (${target.os}/${target.cpu})`,
+    repository: rootPkg.repository,
+    author: rootPkg.author,
+    license: rootPkg.license,
+    os: [target.os],
+    cpu: [target.cpu],
+    files: [target.binary, 'LICENSE'],
+    // Yarn's Plug'n'Play keeps packages zipped by default, which would leave
+    // the launcher with no executable to spawn. Since npm no longer unpacks
+    // this package on our behalf via `bin`, ask for it explicitly.
+    preferUnplugged: true,
+    [BINARY_FIELD]: target.binary
+  }
+}
+
 export function subPackageDir (t: Target): string {
   return `dist/cli-${t.cpu}-${t.os}`
 }
@@ -73,9 +120,19 @@ const ENTRY_POINT = `./${BUNDLE_PATH}`
 
 // Runs a native compilation for `target`, writing the binary to `outputPath`
 // (the full path including the binary filename). Prints command output.
+//
+// The explicit chmod matters for publishing: because sub-packages don't declare
+// `bin` (see BINARY_FIELD), npm never fixes the mode at install time, so the
+// executable bit has to be present in the published tarball itself. npm's
+// packing preserves it; `deno compile` normally sets it, and this makes that a
+// guarantee rather than an assumption. Skipped on Windows, which has no
+// executable bit.
 export async function compileBinary (outputPath: string, target: Target): Promise<void> {
   await shell(
     `deno compile -o ${outputPath} --target ${target.denoTarget} ${COMPILE_FLAGS} ${ENTRY_POINT}`,
     { printOutput: true }
   )
+  if (target.os !== 'win32') {
+    await Deno.chmod(outputPath, 0o755)
+  }
 }

--- a/scripts/targets.ts
+++ b/scripts/targets.ts
@@ -59,6 +59,12 @@ export function subPackageName (t: Target): string {
 // `bin` entries.
 export const BINARY_FIELD = 'chelBinary'
 
+// Mode the native binaries are published with. Shared by the compile step and
+// the sub-package staging step so the two cannot drift; both need it because
+// the executable bit has to be present in the published tarball itself (see
+// BINARY_FIELD for why npm never sets it for us).
+export const EXEC_MODE = 0o755
+
 // Subset of the root package.json that sub-packages inherit metadata from.
 export interface RootPackageMeta {
   version: string
@@ -137,6 +143,6 @@ export async function compileBinary (outputPath: string, target: Target): Promis
     { printOutput: true }
   )
   if (target.os !== 'win32') {
-    await Deno.chmod(outputPath, 0o755)
+    await Deno.chmod(outputPath, EXEC_MODE)
   }
 }

--- a/src/commands.test.ts
+++ b/src/commands.test.ts
@@ -1,0 +1,34 @@
+import { assertEquals } from 'jsr:@std/assert'
+import * as commands from './commands.ts'
+import type { CommandModule } from './commands.ts'
+
+// Commands that read server/database config from `chel.toml` must opt into
+// validation so misconfiguration fails fast; commands that only touch files or
+// a remote URL must NOT, so a malformed config file can't block them (see
+// `parseConfig.ts`). These lists force a deliberate decision whenever a new
+// command is added: the "accounted for" step fails until it is classified.
+const validatesConfig = ['serve', 'migrate', 'get', 'upload', 'eventsAfter', 'pin', 'deploy']
+const skipsValidation = ['hash', 'init', 'keygen', 'manifest', 'verifySignature', 'version']
+
+Deno.test('command config-validation opt-in', async (t) => {
+  const modules = commands as unknown as Record<string, CommandModule<object, object>>
+
+  await t.step('every exported command is accounted for', () => {
+    assertEquals(
+      Object.keys(modules).sort(),
+      [...validatesConfig, ...skipsValidation].sort()
+    )
+  })
+
+  for (const name of validatesConfig) {
+    await t.step(`${name} opts into chel.toml validation`, () => {
+      assertEquals(modules[name].validatesConfig, true)
+    })
+  }
+
+  for (const name of skipsValidation) {
+    await t.step(`${name} does not validate chel.toml`, () => {
+      assertEquals(modules[name].validatesConfig, undefined)
+    })
+  }
+})

--- a/test/bin-chel.test.ts
+++ b/test/bin-chel.test.ts
@@ -131,7 +131,7 @@ Deno.test('bin/chel.js reports a missing binary without a stack trace', async ()
     await Deno.remove(`${tmpDir}/${name}/fake-chel.js`)
     const { code, stderr } = await runShimCapturingStderr(tmpDir)
     assertEquals(code, 126)
-    assertStringIncludes(stderr, 'the file is missing')
+    assertStringIncludes(stderr, 'its binary is missing')
     assertEquals(stderr.includes('    at '), false)
   } finally {
     await Deno.remove(tmpDir, { recursive: true })

--- a/test/bin-chel.test.ts
+++ b/test/bin-chel.test.ts
@@ -6,6 +6,15 @@ await Deno.mkdir('./test/temp', { recursive: true })
 
 const BIN_CHEL = new URL('../bin/chel.js', import.meta.url).pathname
 
+// The fake sub-package binary is a Node script with a shebang, which only
+// Unix kernels know how to execute. Windows resolves the fallback name to
+// chel.exe and CreateProcessW refuses to run a text file, so the shim reports
+// a spawn error rather than the child's real outcome. Signal delivery differs
+// too: Windows has no real SIGTERM, so a killed child never reports a signal
+// and 128+signum cannot be observed. Tests that need to actually run the fake
+// binary are therefore Unix-only.
+const SKIP_SPAWNING_TESTS = Deno.build.os === 'windows'
+
 // Determines the sub-package name that bin/chel.js will look for on this
 // machine, by asking Node directly (avoids hardcoding arch/platform mappings).
 async function currentSubPkgName (): Promise<string> {
@@ -74,6 +83,7 @@ async function runShimCapturingStderr (
 }
 
 Deno.test('bin/chel.js forwards normal exit code from child', async () => {
+  if (SKIP_SPAWNING_TESTS) return
   const tmpDir = await Deno.makeTempDir({ dir: './test/temp' })
   try {
     const name = await currentSubPkgName()
@@ -86,6 +96,7 @@ Deno.test('bin/chel.js forwards normal exit code from child', async () => {
 })
 
 Deno.test('bin/chel.js exits 128+signum when child dies by signal', async () => {
+  if (SKIP_SPAWNING_TESTS) return
   const tmpDir = await Deno.makeTempDir({ dir: './test/temp' })
   try {
     const name = await currentSubPkgName()
@@ -98,6 +109,7 @@ Deno.test('bin/chel.js exits 128+signum when child dies by signal', async () => 
 })
 
 Deno.test('bin/chel.js falls back to the default binary name', async () => {
+  if (SKIP_SPAWNING_TESTS) return
   const tmpDir = await Deno.makeTempDir({ dir: './test/temp' })
   try {
     const name = await currentSubPkgName()

--- a/test/bin-chel.test.ts
+++ b/test/bin-chel.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from 'jsr:@std/assert'
+import { assertEquals, assertStringIncludes } from 'jsr:@std/assert'
 
 // Ensures ./test/temp exists on a fresh checkout (same pattern as
 // sync-versions.test.ts). --allow-write=. in the test task covers it.
@@ -21,25 +21,33 @@ async function currentSubPkgName (): Promise<string> {
 
 // Creates a fake sub-package under tmpDir whose "binary" is a Node script with
 // a shebang, so bin/chel.js can spawn it directly. `binaryScript` is the JS
-// body the fake binary runs.
+// body the fake binary runs. The binary is advertised the way real
+// sub-packages do it (`chelBinary`, never `bin`) unless `omitBinaryField` asks
+// for the pre-`chelBinary` layout, where the shim must fall back to the
+// platform's default filename.
 async function setupFakePackage (
   tmpDir: string,
   subPkgName: string,
-  binaryScript: string
+  binaryScript: string,
+  { omitBinaryField = false }: { omitBinaryField?: boolean } = {}
 ): Promise<void> {
   const pkgDir = `${tmpDir}/${subPkgName}`
   await Deno.mkdir(pkgDir, { recursive: true })
+
+  const binaryName = omitBinaryField
+    ? (Deno.build.os === 'windows' ? 'chel.exe' : 'chel')
+    : 'fake-chel.js'
 
   await Deno.writeTextFile(
     `${pkgDir}/package.json`,
     JSON.stringify({
       name: subPkgName,
       version: '0.0.0-test',
-      bin: { chel: 'fake-chel.js' }
+      ...(omitBinaryField ? {} : { chelBinary: binaryName })
     })
   )
 
-  const binaryPath = `${pkgDir}/fake-chel.js`
+  const binaryPath = `${pkgDir}/${binaryName}`
   await Deno.writeTextFile(binaryPath, `#!/usr/bin/env node\n${binaryScript}\n`)
   await Deno.chmod(binaryPath, 0o755)
 }
@@ -47,15 +55,22 @@ async function setupFakePackage (
 // Spawns `node bin/chel.js` with NODE_PATH set so the fake sub-package is
 // resolved. Returns the process exit code.
 async function runShim (nodePath: string): Promise<number> {
+  return (await runShimCapturingStderr(nodePath)).code
+}
+
+// As runShim, but also returns stderr so error messages can be asserted on.
+async function runShimCapturingStderr (
+  nodePath: string
+): Promise<{ code: number, stderr: string }> {
   const cmd = new Deno.Command('node', {
     args: [BIN_CHEL],
     env: { ...Deno.env.toObject(), NODE_PATH: nodePath },
     stdin: 'null',
     stdout: 'null',
-    stderr: 'null'
+    stderr: 'piped'
   })
   const output = await cmd.output()
-  return output.code
+  return { code: output.code, stderr: new TextDecoder().decode(output.stderr) }
 }
 
 Deno.test('bin/chel.js forwards normal exit code from child', async () => {
@@ -77,6 +92,64 @@ Deno.test('bin/chel.js exits 128+signum when child dies by signal', async () => 
     await setupFakePackage(tmpDir, name, "process.kill(process.pid, 'SIGTERM')")
     const code = await runShim(tmpDir)
     assertEquals(code, 143) // 128 + 15 (SIGTERM)
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true })
+  }
+})
+
+Deno.test('bin/chel.js falls back to the default binary name', async () => {
+  const tmpDir = await Deno.makeTempDir({ dir: './test/temp' })
+  try {
+    const name = await currentSubPkgName()
+    await setupFakePackage(tmpDir, name, 'process.exit(7)', { omitBinaryField: true })
+    const code = await runShim(tmpDir)
+    assertEquals(code, 7)
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true })
+  }
+})
+
+Deno.test('bin/chel.js reports an unsupported platform without a stack trace', async () => {
+  const tmpDir = await Deno.makeTempDir({ dir: './test/temp' })
+  try {
+    // Nothing installed under tmpDir, so the sub-package cannot be resolved.
+    const { code, stderr } = await runShimCapturingStderr(tmpDir)
+    assertEquals(code, 127)
+    assertStringIncludes(stderr, 'is not installed')
+    assertEquals(stderr.includes('    at '), false)
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true })
+  }
+})
+
+Deno.test('bin/chel.js reports a missing binary without a stack trace', async () => {
+  const tmpDir = await Deno.makeTempDir({ dir: './test/temp' })
+  try {
+    const name = await currentSubPkgName()
+    await setupFakePackage(tmpDir, name, 'process.exit(0)')
+    // Simulate a corrupt install: the sub-package is there, the binary is not.
+    await Deno.remove(`${tmpDir}/${name}/fake-chel.js`)
+    const { code, stderr } = await runShimCapturingStderr(tmpDir)
+    assertEquals(code, 126)
+    assertStringIncludes(stderr, 'the file is missing')
+    assertEquals(stderr.includes('    at '), false)
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true })
+  }
+})
+
+Deno.test('bin/chel.js reports a non-executable binary', async () => {
+  if (Deno.build.os === 'windows') return // no executable bit on Windows
+  const tmpDir = await Deno.makeTempDir({ dir: './test/temp' })
+  try {
+    const name = await currentSubPkgName()
+    await setupFakePackage(tmpDir, name, 'process.exit(0)')
+    // The exec bit now comes from the published tarball rather than from npm,
+    // so losing it must produce a clear diagnostic.
+    await Deno.chmod(`${tmpDir}/${name}/fake-chel.js`, 0o644)
+    const { code, stderr } = await runShimCapturingStderr(tmpDir)
+    assertEquals(code, 126)
+    assertStringIncludes(stderr, 'not executable')
   } finally {
     await Deno.remove(tmpDir, { recursive: true })
   }


### PR DESCRIPTION
This PR improves upon two things in terms of the build process. (AI disclosure: generated with Claude Opus 5)

## Support for installing with `npm 10`

The previous way of building the subpackages meant that the `chel` binary wasn't always available under `node_modules/.bin` if using `npm 10` (for example, the version of `npm` that usually comes with Node.js 22).

This PR fixes that by removing the `bin` field from `package.json`

## Build efficiency

The previous way of building also meant that some steps were executed redundantly. For example, for publishing the bundle would be generated and then the binaries, and these steps would be repeated after running `deno task dist`, which is needed for producing the tarballs.

This PR fixes that by avoiding re-running steps that have already been done.